### PR TITLE
fix!: remove ucan bucket interface

### DIFF
--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -110,10 +110,6 @@ export interface DudewhereBucket {
   put: (dataCid: string, carCid: string) => Promise<void>
 }
 
-export interface UcanBucket {
-  put: (carCid: string, bytes: Uint8Array) => Promise<void>
-}
-
 export interface StoreTable {
   exists: (space: DID, link: UnknownLink) => Promise<boolean>
   insert: (item: StoreAddInput) => Promise<StoreAddOutput>


### PR DESCRIPTION
See https://github.com/web3-storage/w3infra/blob/main/upload-api/functions/ucan-invocation-router.js#L66-L88 where this bucket is created but not provided to `upload-api` ucanto server

BREAKING CHANGE: ucan bucket is not part of upload-api but rather ucan-api