### PR TITLE
fix: revert "feat: upload-client funcs have options.piece to opt in to piece link calculation (#1220)

### DIFF
--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -130,14 +130,12 @@ async function uploadBlockStream(conf, blocks, options = {}) {
         const bytes = new Uint8Array(await car.arrayBuffer())
         const [cid, piece] = await Promise.all([
           Store.add(conf, bytes, options),
-          options.piece
-            ? (async () => {
-                const multihashDigest = await PieceHasher.digest(bytes)
-                return /** @type {import('@web3-storage/capabilities/types').PieceLink} */ (
-                  Link.create(raw.code, multihashDigest)
-                )
-              })()
-            : undefined,
+          (async () => {
+            const multihashDigest = await PieceHasher.digest(bytes)
+            return /** @type {import('@web3-storage/capabilities/types').PieceLink} */ (
+              Link.create(raw.code, multihashDigest)
+            )
+          })(),
         ])
         const { version, roots, size } = car
         return { version, roots, size, cid, piece }

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -167,7 +167,7 @@ export interface CARMetadata extends CARHeaderInfo {
    *
    * @see https://github.com/filecoin-project/FIPs/pull/758/files
    */
-  piece?: PieceLink
+  piece: PieceLink
   /**
    * Size of the CAR file in bytes.
    */
@@ -253,8 +253,6 @@ export interface UploadOptions
     ShardStoringOptions,
     UploadProgressTrackable {
   onShardStored?: (meta: CARMetadata) => void
-  /** when true, uploading will calculate filecoin piece link */
-  piece?: true
 }
 
 export interface UploadDirectoryOptions

--- a/packages/upload-client/test/index.test.js
+++ b/packages/upload-client/test/index.test.js
@@ -705,7 +705,7 @@ describe('uploadCAR', () => {
       car,
       {
         connection,
-        onShardStored: (meta) => meta.piece && pieceCIDs.push(meta.piece),
+        onShardStored: (meta) => pieceCIDs.push(meta.piece),
       }
     )
 
@@ -713,28 +713,9 @@ describe('uploadCAR', () => {
     assert.equal(service.store.add.callCount, 1)
     assert(service.upload.add.called)
     assert.equal(service.upload.add.callCount, 1)
-    // pieceCID calculation is disabled by default
-    assert.equal(pieceCIDs.length, 0)
-
-    // can opt in to calculating piece link
-    /** @type {Array<import('@web3-storage/upload-client/types').CARMetadata>} */
-    const shards2 = []
-    await uploadCAR(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      car,
-      {
-        connection,
-        onShardStored: (meta) => shards2.push(meta),
-        piece: true,
-      }
-    )
-    assert.equal(shards2.length, 1)
-    assert.ok(
-      shards2[0].piece,
-      'shard piece cid is truthy because options.piece=true'
-    )
+    assert.equal(pieceCIDs.length, 1)
     assert.equal(
-      shards2[0].piece.toString(),
+      pieceCIDs[0].toString(),
       'bafkzcibcoibrsisrq3nrfmsxvynduf4kkf7qy33ip65w7ttfk7guyqod5w5mmei'
     )
   })


### PR DESCRIPTION
This reverts commit c38000ecff19f9d402d1f1912e67153a0fe7284c.

Needs https://github.com/web3-storage/w3up/pull/1223 merged.

Alternatively, we can keep the code as is and make the default true. However, I feel that our current way of making computation in the client and not do Bucket events would go against supporting this as optional