### PR TITLE
refactor: Avoid conflation of Space and Account

### DIFF
--- a/.github/workflows/access-client.yml
+++ b/.github/workflows/access-client.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/blob-index.yml
+++ b/.github/workflows/blob-index.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/did-mailto.yml
+++ b/.github/workflows/did-mailto.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/filecoin-api.yml
+++ b/.github/workflows/filecoin-api.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup
         uses: actions/setup-node@v3

--- a/.github/workflows/upload-api.yml
+++ b/.github/workflows/upload-api.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup
         uses: actions/setup-node@v3
@@ -61,8 +59,6 @@ jobs:
 
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup
         uses: actions/setup-node@v3

--- a/.github/workflows/w3up-client.yml
+++ b/.github/workflows/w3up-client.yml
@@ -31,8 +31,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
* `space.signer.withDID(account)` gives us a Signer with the Space's key, but which reports the Account's DID. It looks like this might have been needed at some point when this thing was actually used to sign something. But as of now, we don't need a *Signer*, just a DID, and a `did:mailto:` is fine. So, simplify this.

* This was being passed as the `agent`, but it's not an Agent. `createAuthorization()` doesn't need an Agent, it needs an *audience*. In some cases that's an Agent, in some cases it's an Account. This changes the name to clarify.