### PR TITLE
fix: remove redundant package manager version

### DIFF
--- a/.github/workflows/access-client.yml
+++ b/.github/workflows/access-client.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/blob-index.yml
+++ b/.github/workflows/blob-index.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/capabilities.yml
+++ b/.github/workflows/capabilities.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/did-mailto.yml
+++ b/.github/workflows/did-mailto.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/filecoin-api.yml
+++ b/.github/workflows/filecoin-api.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup
         uses: actions/setup-node@v3

--- a/.github/workflows/filecoin-client.yml
+++ b/.github/workflows/filecoin-client.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -29,8 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -53,8 +51,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/upload-api.yml
+++ b/.github/workflows/upload-api.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup
         uses: actions/setup-node@v3
@@ -61,8 +59,6 @@ jobs:
 
       - name: Install
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup
         uses: actions/setup-node@v3

--- a/.github/workflows/upload-client.yml
+++ b/.github/workflows/upload-client.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}


### PR DESCRIPTION
Apparently this is not needed when `packageManager` is set in root `package.json`.