### PR TITLE
fix: repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `w3up`
 
-This repo implements the web3.storage UCAN protocol [specifications](https://github.com/web3-storage/specs).
+This repo implements the web3.storage UCAN protocol [specifications](https://github.com/storacha/specs).
 
 It's the core of the web3.storage server and client implementations.
 
@@ -18,7 +18,7 @@ Once uploaded you can fetch your data from any IPFS gateway via [`https://w3s.li
 
 ### Command Line
 
-Install [`@web3-storage/w3cli`](https://github.com/web3-storage/w3cli#readme) globally, authorize it to act on your behalf, create a space and upload your files. It calculates the root CID for your files locally before sending them to web3.storage.
+Install [`@web3-storage/w3cli`](https://github.com/storacha/w3cli#readme) globally, authorize it to act on your behalf, create a space and upload your files. It calculates the root CID for your files locally before sending them to web3.storage.
 
 **shell**
 ```shell
@@ -34,11 +34,11 @@ $ w3 up ~/Pictures/ayy-lamo.jpg
 ⁂ https://w3s.link/ipfs/bafybeid6gpbsqkpfrsx6b6ywrt24je4xqe4eo4y2wldisl6sk7byny5uky
 ```
 
-Run `w3 --help` or have a look at https://github.com/web3-storage/w3cli to find out everything it can do.
+Run `w3 --help` or have a look at https://github.com/storacha/w3cli to find out everything it can do.
 
 ### JS Client
 
-Add the [`@web3-storage/w3up-client`](https://www.npmjs.com/package/@web3-storage/w3up-client) module into your project with `npm i @web3-storage/w3up-client` and upload a single file with [`client.uploadFile`](https://github.com/web3-storage/w3up/blob/main/packages/w3up-client/README.md#uploadfile) or many with [`client.uploadDirectory`](https://github.com/web3-storage/w3up/blob/main/packages/w3up-client/README.md#uploaddirectory).
+Add the [`@web3-storage/w3up-client`](https://www.npmjs.com/package/@web3-storage/w3up-client) module into your project with `npm i @web3-storage/w3up-client` and upload a single file with [`client.uploadFile`](https://github.com/storacha/w3up/blob/main/packages/w3up-client/README.md#uploadfile) or many with [`client.uploadDirectory`](https://github.com/storacha/w3up/blob/main/packages/w3up-client/README.md#uploaddirectory).
 
 If you've already got a space you can upload like this:
  
@@ -63,11 +63,11 @@ console.log(`Gateway URL: https://w3s.link/ipfs/${cid}`)
 
 See https://web3.storage/docs/w3up-client for a guide to using the js client for the first time.
 
-For an interactive command line adventure into the using w3up check out `learnyouw3up` here https://github.com/web3-storage/learnyouw3up
+For an interactive command line adventure into the using w3up check out `learnyouw3up` here https://github.com/storacha/learnyouw3up
 
 ### GitHub Action 
 
-The Action [`add-to-web3`](https://github.com/marketplace/actions/add-to-web3) wraps [`w3cli`](https://github.com/web3-storage/w3cli) to let you add files to web3.storage from your GitHub Workflows.
+The Action [`add-to-web3`](https://github.com/marketplace/actions/add-to-web3) wraps [`w3cli`](https://github.com/storacha/w3cli) to let you add files to web3.storage from your GitHub Workflows.
 
 **github-workflow.yaml**
 ```yaml
@@ -86,13 +86,13 @@ The Action [`add-to-web3`](https://github.com/marketplace/actions/add-to-web3) w
 # "https://dweb.link/ipfs/bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am"
 ```
 
-To generate a `secret_key` and delegate permissions to it as a `proof` to use in CI see: https://github.com/web3-storage/add-to-web3#generating-a-secret_key-and-proof
+To generate a `secret_key` and delegate permissions to it as a `proof` to use in CI see: https://github.com/storacha/add-to-web3#generating-a-secret_key-and-proof
 
 ## Contributing
 
 All welcome! web3.storage is open-source. See the [contributing guide](./CONTRIBUTING.md)
 
-This project uses node v18 and `pnpm`. It's a monorepo that uses [pnpm workspaces](https://pnpm.io/workspaces) to handle resolving dependencies between the local [`packages`](https://github.com/web3-storage/w3up/tree/main/packages)
+This project uses node v18 and `pnpm`. It's a monorepo that uses [pnpm workspaces](https://pnpm.io/workspaces) to handle resolving dependencies between the local [`packages`](https://github.com/storacha/w3up/tree/main/packages)
 
 ## License
 

--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/access-client"
   },
   "author": "Hugo Dias <hugomrdias@gmail.com> (hugodias.me)",

--- a/packages/access-client/readme.md
+++ b/packages/access-client/readme.md
@@ -5,13 +5,13 @@
 
 The `@web3-storage/access` package provides an API for creating and managing "agents," which are software entities that control private signing keys and can invoke capabilities on behalf of a user (or another agent).
 
-Agents are used to invoke capabilities provided by the w3up service layer, using the [ucanto](https://github.com/web3-storage/ucanto) RPC framework. Agents are created locally on an end-user's device, and users are encouraged to create new agents for each device (or browser) that they want to use, rather than sharing agent keys between devices.
+Agents are used to invoke capabilities provided by the w3up service layer, using the [ucanto](https://github.com/storacha/ucanto) RPC framework. Agents are created locally on an end-user's device, and users are encouraged to create new agents for each device (or browser) that they want to use, rather than sharing agent keys between devices.
 
 An Agent can create "spaces," which are namespaces for content stored on the w3up platform. Each space has its own keypair, the public half of which is used to form a `did:key:` URI that uniquely identifies the space. The space's private key is used to delegate capabilities to a primary agent, which then issues ucanto requests related to the space.
 
 Although agents (and spaces) are created locally by generating keypairs, the w3up services will only act upon spaces that have been registered with the w3up access service. By default, a newly-created agent will be configured to use the production access service for remote operations, including registration.
 
-Please note that the `@web3-storage/access` package is a fairly "low level" component of the w3up JavaScript stack, and most users will be better served by [`@web3-storage/w3up-client`](https://github.com/web3-storage/w3up-client), which combines this package with a client for the upload and storage service and presents a simpler API.
+Please note that the `@web3-storage/access` package is a fairly "low level" component of the w3up JavaScript stack, and most users will be better served by [`@web3-storage/w3up-client`](https://github.com/storacha/w3up-client), which combines this package with a client for the upload and storage service and presents a simpler API.
 
 ## Install
 
@@ -23,13 +23,13 @@ npm install @web3-storage/access
 
 ## Usage
 
-[API Reference](https://web3-storage.github.io/w3protocol/modules/_web3_storage_access.html)
+[API Reference](https://web3-storage.github.io/w3up/modules/_web3_storage_access.html)
 
 ### Agent creation
 
 To create an agent, you must first create a `Store`, which the agent will use to store and manage persistent state, including private keys.
 
-If you're running in a web browser, use [`StoreIndexedDB`](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.StoreIndexedDB.html), which uses IndexedDB to store non-extractable [`CryptoKey`](https://www.w3.org/TR/WebCryptoAPI/#dfn-CryptoKey) objects. This prevents the private key material from ever being exposed to the JavaScript environment.
+If you're running in a web browser, use [`StoreIndexedDB`](https://web3-storage.github.io/w3up/classes/_web3_storage_access.StoreIndexedDB.html), which uses IndexedDB to store non-extractable [`CryptoKey`](https://www.w3.org/TR/WebCryptoAPI/#dfn-CryptoKey) objects. This prevents the private key material from ever being exposed to the JavaScript environment.
 
 Agents in a browser use RSA keys, which can be generated using the async `generate` function from `@ucanto/principal/rsa`.
 
@@ -58,7 +58,7 @@ async function createAgent() {
 }
 ```
 
-On node.js, use [`StoreConf`](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.StoreConf.html), which uses the [`conf` package](https://www.npmjs.com/package/conf) to store keys and metadata in the user's platform-specific default configuration location (usually in their home directory).
+On node.js, use [`StoreConf`](https://web3-storage.github.io/w3up/classes/_web3_storage_access.StoreConf.html), which uses the [`conf` package](https://www.npmjs.com/package/conf) to store keys and metadata in the user's platform-specific default configuration location (usually in their home directory).
 
 Agents on node should use Ed25519 keys:
 
@@ -91,13 +91,13 @@ async function createAgent() {
 
 ```
 
-See the [`AgentCreateOptions` reference](https://web3-storage.github.io/w3protocol/interfaces/_web3_storage_access._internal_.AgentCreateOptions.html) if you want to configure the agent to use a non-production service connection.
+See the [`AgentCreateOptions` reference](https://web3-storage.github.io/w3up/interfaces/_web3_storage_access._internal_.AgentCreateOptions.html) if you want to configure the agent to use a non-production service connection.
 
 ### Space creation
 
 A newly-created agent does not have access to any spaces, and is thus unable to store data using the w3up platform.
 
-To create a new space, use [`agent.createSpace`](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#createSpace), optionally passing in a human-readable name.
+To create a new space, use [`agent.createSpace`](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#createSpace), optionally passing in a human-readable name.
 
 This will create a new signing keypair for the space and use it to issue a non-expiring delegation for all space-related capabilities to the agent, which will persist the delegation in its Store for future use.
 
@@ -126,21 +126,21 @@ interface CreateSpaceResult {
 
 An agent can create multiple spaces and may also be issued delegations that allow it to manage spaces created by other agents. The agent's `spaces` property is a `Map` keyed by space DID, whose values are the metadata associated with each space.
 
-Agents may also have a "current" space, which is used as the default space for storage operations if none is specified. You can retrieve the DID of the current space with [`agent.currentSpace`](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#currentSpace). If you also want the metadata and proofs associated with the space, use [`agent.currentSpaceWithMeta`](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#currentSpaceWithMeta).
+Agents may also have a "current" space, which is used as the default space for storage operations if none is specified. You can retrieve the DID of the current space with [`agent.currentSpace`](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#currentSpace). If you also want the metadata and proofs associated with the space, use [`agent.currentSpaceWithMeta`](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#currentSpaceWithMeta).
 
-To set the current space, use [`agent.setCurrentSpace`](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#setCurrentSpace). Note that this must be done explicitly; creating an agent's first space does not automatically set it as the current space.
+To set the current space, use [`agent.setCurrentSpace`](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#setCurrentSpace). Note that this must be done explicitly; creating an agent's first space does not automatically set it as the current space.
 
 ### Space registration
 
 A newly-created space must be registered with the w3up access service before it can be used as a storage location.
 
-To register a space, use [`agent.registerSpace`](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#registerSpace), which takes an email address parameter and registers the [current space](#managing-the-current-space) with the access service.
+To register a space, use [`agent.registerSpace`](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#registerSpace), which takes an email address parameter and registers the [current space](#managing-the-current-space) with the access service.
 
 Calling `registerSpace` will cause the access service to send a confirmation email to the provided email address. When the activation link in the email is clicked, the service will send the agent a delegation via a WebSocket connection that grants access to the services included in w3up's free tier. The `registerSpace` method returns a `Promise` that resolves once the registration process is complete. Make sure to wrap calls to `registerSpace` in a `try/catch` block, as registration will fail if the user does not confirm the email (or if network issues arise, etc.).
 
 ### Delegating to another agent
 
-The agent's [`delegate` method](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#delegate) allows you to delegate capabilities to another agent.
+The agent's [`delegate` method](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#delegate) allows you to delegate capabilities to another agent.
 
 ```js
 const delegation = await agent.delegate({
@@ -158,15 +158,15 @@ Note that the receiving agent will need to [import the delegation](#importing-de
 
 ### Importing delegations from another agent
 
-The [`addProof` method](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#addProof) takes in a ucanto `Delegation` and adds it to the agent's state Store. The proof of delegation can be retrieved using the agent's [`proofs` method](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#proofs).
+The [`addProof` method](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#addProof) takes in a ucanto `Delegation` and adds it to the agent's state Store. The proof of delegation can be retrieved using the agent's [`proofs` method](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#proofs).
 
-The [`importSpaceFromDelegation` method](https://web3-storage.github.io/w3protocol/classes/_web3_storage_access.Agent.html#importSpaceFromDelegation) also accepts a ucanto `Delegation`, but it is tailored for "full delegation" of all space-related capabilities. The delegated ability must be `*`, which is the "top" ability that can derive all abilities for the Space's DID. Use `importSpaceFromDelegation` in preference to `addProofs` when importing a full `*` delegation for a space, as it also adds metadata about the imported space to the Agent's persistent store and adds the space to the agent's set of authorized spaces.
+The [`importSpaceFromDelegation` method](https://web3-storage.github.io/w3up/classes/_web3_storage_access.Agent.html#importSpaceFromDelegation) also accepts a ucanto `Delegation`, but it is tailored for "full delegation" of all space-related capabilities. The delegated ability must be `*`, which is the "top" ability that can derive all abilities for the Space's DID. Use `importSpaceFromDelegation` in preference to `addProofs` when importing a full `*` delegation for a space, as it also adds metadata about the imported space to the Agent's persistent store and adds the space to the agent's set of authorized spaces.
 
 ## Contributing
 
-Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3protocol/issues)!
+Feel free to join in. All welcome. Please [open an issue](https://github.com/storacha/w3up/issues)!
 
 ## License
 
-Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3protocol/blob/main/license.md)
+Dual-licensed under [MIT + Apache 2.0](https://github.com/storacha/w3up/blob/main/license.md)
 

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -239,7 +239,7 @@ export class Agent {
       }
     }
     const receipt = await this.invokeAndExecute(UCAN.revoke, {
-      // per https://github.com/web3-storage/w3up/blob/main/packages/capabilities/src/ucan.js#L38C6-L38C6 the resource here should be
+      // per https://github.com/storacha/w3up/blob/main/packages/capabilities/src/ucan.js#L38C6-L38C6 the resource here should be
       // the current issuer - using the space DID here works for simple cases but falls apart when a delegee tries to revoke a delegation
       // they have re-delegated, since they don't have "ucan/revoke" capabilities on the space
       with: this.issuer.did(),

--- a/packages/blob-index/README.md
+++ b/packages/blob-index/README.md
@@ -55,8 +55,8 @@ for (const [shard, slices] of index.shards.entries()) {
 
 ## Contributing
 
-Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3up/issues)!
+Feel free to join in. All welcome. Please [open an issue](https://github.com/storacha/w3up/issues)!
 
 ## License
 
-Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3up/blob/main/license.md)
+Dual-licensed under [MIT + Apache 2.0](https://github.com/storacha/w3up/blob/main/license.md)

--- a/packages/blob-index/package.json
+++ b/packages/blob-index/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/blob-index"
   },
   "license": "Apache-2.0 OR MIT",

--- a/packages/blob-index/src/api.ts
+++ b/packages/blob-index/src/api.ts
@@ -12,7 +12,7 @@ export type Position = [offset: number, length: number]
 /**
  * A sharded DAG index.
  *
- * @see https://github.com/w3s-project/specs/blob/main/w3-index.md
+ * @see https://github.com/storacha/specs/blob/main/w3-index.md
  */
 export interface ShardedDAGIndex {
   /** DAG root CID that the index pertains to. */

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/capabilities"
   },
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/capabilities/readme.md
+++ b/packages/capabilities/readme.md
@@ -4,11 +4,11 @@
 
 ## About
 
-The w3up platform by [web3.storage](https://web3.storage) is implemented as a set of capabilities that can be invoked using the [ucanto](https://github.com/web3-storage/ucanto) RPC framework.
+The w3up platform by [web3.storage](https://web3.storage) is implemented as a set of capabilities that can be invoked using the [ucanto](https://github.com/storacha/ucanto) RPC framework.
 
 The `@web3-storage/capabilities` package contains capability definitions, which are used by clients to create invocations and by services to validate and parse invocations and route requests to the correct capability handler.
 
-See the [capabilities spec](https://github.com/web3-storage/w3protocol/tree/main/spec/capabilities.md) for more information about each capability included in this package.
+See the [capabilities spec](https://github.com/storacha/w3up/tree/main/spec/capabilities.md) for more information about each capability included in this package.
 
 ## Install
 
@@ -19,8 +19,6 @@ npm install @web3-storage/capabilities
 ```
 
 ## Usage
-
-[API Reference](https://web3-storage.github.io/w3protocol/modules/_web3_storage_capabilities.html)
 
 ```js
 import * as Space from '@web3-storage/capabilities/space'
@@ -117,7 +115,7 @@ interface UCANOptions {
 }
 ```
 
-In the example below, we're generating a new `Signer` to act as the issuer of the invocation using the `@ucanto/principal/ed25519` package. Note that in a real application, the service would likely reject an invocation from this signer, as it does not have any delegated permissions. See the [access client package](https://github.com/web3-storage/w3protocol/tree/main/packages/access-client) for more about key management and delegation in practice.
+In the example below, we're generating a new `Signer` to act as the issuer of the invocation using the `@ucanto/principal/ed25519` package. Note that in a real application, the service would likely reject an invocation from this signer, as it does not have any delegated permissions. See the [access client package](https://github.com/storacha/w3up/tree/main/packages/access-client) for more about key management and delegation in practice.
 
 ```ts
 import * as DID from '@ipld/dag-ucan/did'

--- a/packages/capabilities/src/access.js
+++ b/packages/capabilities/src/access.js
@@ -115,13 +115,13 @@ export const claim = capability({
   with: DID.match({ method: 'key' }).or(DID.match({ method: 'mailto' })),
 })
 
-// https://github.com/web3-storage/specs/blob/main/w3-access.md#accessdelegate
+// https://github.com/storacha/specs/blob/main/w3-access.md#accessdelegate
 export const delegate = capability({
   can: 'access/delegate',
   /**
    * Field MUST be a space DID with a storage provider. Delegation will be stored just like any other DAG stored using store/add capability.
    *
-   * @see https://github.com/web3-storage/specs/blob/main/w3-access.md#delegate-with
+   * @see https://github.com/storacha/specs/blob/main/w3-access.md#delegate-with
    */
   with: SpaceDID,
   nb: Schema.struct({

--- a/packages/capabilities/src/ucan.js
+++ b/packages/capabilities/src/ucan.js
@@ -106,7 +106,7 @@ export const conclude = capability({
  * Issued by trusted authority (usually the one handling invocation) that attest
  * that specific UCAN delegation has been considered authentic.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-session.md#authorization-session
+ * @see https://github.com/storacha/specs/blob/main/w3-session.md#authorization-session
  * 
  * @example
  * ```js

--- a/packages/did-mailto/package.json
+++ b/packages/did-mailto/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/did-mailto"
   },
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/eslint-config-w3up/package.json
+++ b/packages/eslint-config-w3up/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/eslint-config-w3up"
   },
   "main": "index.js",

--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/filecoin-api"
   },
   "files": [

--- a/packages/filecoin-client/README.md
+++ b/packages/filecoin-client/README.md
@@ -3,7 +3,7 @@
 
 ## About
 
-The `@web3-storage/filecoin-client` package provides the "low level" client API to make data uploaded with the w3up platform available in Filecoin Storage providers. It is based on [web3-storage/specs/w3-filecoin.md](https://github.com/web3-storage/specs/blob/feat/filecoin-spec/w3-filecoin.md) and is not intended for web3.storage end users.
+The `@web3-storage/filecoin-client` package provides the "low level" client API to make data uploaded with the w3up platform available in Filecoin Storage providers. It is based on [web3-storage/specs/w3-filecoin.md](https://github.com/storacha/specs/blob/feat/filecoin-spec/w3-filecoin.md) and is not intended for web3.storage end users.
 
 ## Install
 
@@ -17,7 +17,7 @@ npm install @web3-storage/filecoin-client
 
 ### `Storefront.filecoinOffer`
 
-The [`filecoin/offer`](https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#filecoinoffer) task can be executed to request storing a content piece in Filecoin. It issues a signed receipt of the execution result.
+The [`filecoin/offer`](https://github.com/storacha/specs/blob/main/w3-filecoin.md#filecoinoffer) task can be executed to request storing a content piece in Filecoin. It issues a signed receipt of the execution result.
 
 A receipt for successful execution will contain an effect, linking to a `filecoin/submit` task that will complete asynchronously.
 
@@ -45,7 +45,7 @@ More information: [`InvocationConfig`](#invocationconfig)
 
 ### `Storefront.filecoinSubmit`
 
-The [`filecoin/submit`](https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#filecoinsubmit) task is an _effect_ linked from successful execution of a `filecoin/offer` task, it is executed to issue a receipt for the success or failure of the task.
+The [`filecoin/submit`](https://github.com/storacha/specs/blob/main/w3-filecoin.md#filecoinsubmit) task is an _effect_ linked from successful execution of a `filecoin/offer` task, it is executed to issue a receipt for the success or failure of the task.
 
 A receipt for successful execution indicates that the offered piece has been submitted to the pipeline. In this case the receipt will contain an effect, linking to a `piece/offer` task that will complete asynchronously.
 
@@ -73,7 +73,7 @@ More information: [`InvocationConfig`](#invocationconfig)
 
 ### `Storefront.filecoinAccept`
 
-The [`filecoin/accept`](https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#filecoinsubmit) task is an _effect_ linked from successful execution of a `filecoin/offer` task, it is executed to issue a receipt for the success or failure of the task.
+The [`filecoin/accept`](https://github.com/storacha/specs/blob/main/w3-filecoin.md#filecoinsubmit) task is an _effect_ linked from successful execution of a `filecoin/offer` task, it is executed to issue a receipt for the success or failure of the task.
 
 A receipt for successful execution indicates that the offered piece has been accepted in a Filecoin deal. In this case the receipt will contain proofs that the piece was included in an aggregate and deal.
 
@@ -101,7 +101,7 @@ More information: [`InvocationConfig`](#invocationconfig)
 
 ### `Aggregator.pieceOffer`
 
-The [`piece/offer`](https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#pieceoffer) task can be executed to request that a piece be aggregated for inclusion in an upcoming an Filecoin deal. It issues a signed receipt of the execution result. It is _also_ an effect linked from successful execution of a `filecoin/submit` task.
+The [`piece/offer`](https://github.com/storacha/specs/blob/main/w3-filecoin.md#pieceoffer) task can be executed to request that a piece be aggregated for inclusion in an upcoming an Filecoin deal. It issues a signed receipt of the execution result. It is _also_ an effect linked from successful execution of a `filecoin/submit` task.
 
 A receipt for successful execution will contain an effect, linking to a `piece/accept` task that will complete asynchronously.
 
@@ -129,7 +129,7 @@ More information: [`InvocationConfig`](#invocationconfig)
 
 ### `Aggregator.pieceAccept`
 
-The [`piece/accept`](https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#pieceaccept) task is an _effect_ linked from successful execution of a `piece/offer` task, it is executed to issue a receipt for the success or failure of the task.
+The [`piece/accept`](https://github.com/storacha/specs/blob/main/w3-filecoin.md#pieceaccept) task is an _effect_ linked from successful execution of a `piece/offer` task, it is executed to issue a receipt for the success or failure of the task.
 
 A receipt for successful execution indicates that the offered piece was included in an aggregate. In this case the receipt will contain the aggregate piece CID and a proof that the piece was included in the aggregate. It also includes an effect, linking to an `aggregate/offer` task that will complete asynchronously.
 
@@ -157,7 +157,7 @@ More information: [`InvocationConfig`](#invocationconfig)
 
 ### `Dealer.aggregateOffer`
 
-The [`aggregate/offer`](https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#aggregateoffer) task can be executed to request an aggregate be added to a deal with a Storage Provider. It issues a signed receipt of the execution result. It is _also_ an effect linked from successful execution of a `piece/accept` task.
+The [`aggregate/offer`](https://github.com/storacha/specs/blob/main/w3-filecoin.md#aggregateoffer) task can be executed to request an aggregate be added to a deal with a Storage Provider. It issues a signed receipt of the execution result. It is _also_ an effect linked from successful execution of a `piece/accept` task.
 
 A receipt for successful execution will contain an effect, linking to an `aggregate/accept` task that will complete asynchronously.
 
@@ -185,7 +185,7 @@ More information: [`InvocationConfig`](#invocationconfig)
 
 ### `Dealer.aggregateAccept`
 
-The [`aggregate/accept`](https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#aggregateaccept) task is an _effect_ linked from successful execution of a `aggregate/offer` task, it is executed to issue a receipt for the success or failure of the task.
+The [`aggregate/accept`](https://github.com/storacha/specs/blob/main/w3-filecoin.md#aggregateaccept) task is an _effect_ linked from successful execution of a `aggregate/offer` task, it is executed to issue a receipt for the success or failure of the task.
 
 A receipt for successful execution indicates that an aggregate has been accepted for inclusion in a Filecoin deal. In this case the receipt will contain proofs that the piece was included in an aggregate and deal.
 
@@ -213,7 +213,7 @@ More information: [`InvocationConfig`](#invocationconfig)
 
 ### `DealTracker.dealInfo`
 
-The [`deal/info`](https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#dealinfo) task can be executed to request deal information for a given piece. It issues a signed receipt of the execution result.
+The [`deal/info`](https://github.com/storacha/specs/blob/main/w3-filecoin.md#dealinfo) task can be executed to request deal information for a given piece. It issues a signed receipt of the execution result.
 
 A receipt for successful execution will contain details of deals the provided piece CID is currently active in.
 
@@ -250,9 +250,9 @@ This is the configuration for the UCAN invocation. It is an object with `issuer`
 
 ## Contributing
 
-Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3protocol/issues)!
+Feel free to join in. All welcome. Please [open an issue](https://github.com/storacha/w3up/issues)!
 
 ## License
 
-Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3protocol/blob/main/license.md)
+Dual-licensed under [MIT + Apache 2.0](https://github.com/storacha/w3up/blob/main/license.md)
 

--- a/packages/filecoin-client/README.md
+++ b/packages/filecoin-client/README.md
@@ -3,7 +3,7 @@
 
 ## About
 
-The `@web3-storage/filecoin-client` package provides the "low level" client API to make data uploaded with the w3up platform available in Filecoin Storage providers. It is based on [web3-storage/specs/w3-filecoin.md](https://github.com/storacha/specs/blob/feat/filecoin-spec/w3-filecoin.md) and is not intended for web3.storage end users.
+The `@web3-storage/filecoin-client` package provides the "low level" client API to make data uploaded with the w3up platform available in Filecoin Storage providers. It is based on [storacha/specs/w3-filecoin.md](https://github.com/storacha/specs/blob/main/w3-filecoin.md) and is not intended for web3.storage end users.
 
 ## Install
 

--- a/packages/filecoin-client/package.json
+++ b/packages/filecoin-client/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/w3filecoin-client"
   },
   "author": "Vasco Santos",

--- a/packages/filecoin-client/src/aggregator.js
+++ b/packages/filecoin-client/src/aggregator.js
@@ -30,7 +30,7 @@ export const connection = connect({
  * Otherwise the task is failed and the receipt will contain details of the
  * reason behind the failure.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#pieceoffer
+ * @see https://github.com/storacha/specs/blob/main/w3-filecoin.md#pieceoffer
  *
  * @param {import('./types.js').InvocationConfig} conf - Configuration
  * @param {import('@web3-storage/data-segment').PieceLink} piece
@@ -76,7 +76,7 @@ export async function pieceOffer(
  * Otherwise the task is failed and the receipt will contain details of the
  * reason behind the failure.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#pieceaccept
+ * @see https://github.com/storacha/specs/blob/main/w3-filecoin.md#pieceaccept
  *
  * @param {import('./types.js').InvocationConfig} conf - Configuration
  * @param {import('@web3-storage/data-segment').PieceLink} piece

--- a/packages/filecoin-client/src/deal-tracker.js
+++ b/packages/filecoin-client/src/deal-tracker.js
@@ -28,7 +28,7 @@ export const connection = connect({
  * Otherwise the task is failed and the receipt will contain details of the
  * reason behind the failure.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#dealinfo
+ * @see https://github.com/storacha/specs/blob/main/w3-filecoin.md#dealinfo
  *
  * @param {import('./types.js').InvocationConfig} conf - Configuration
  * @param {import('@web3-storage/data-segment').PieceLink} piece

--- a/packages/filecoin-client/src/dealer.js
+++ b/packages/filecoin-client/src/dealer.js
@@ -31,7 +31,7 @@ export const connection = connect({
  * Otherwise the task is failed and the receipt will contain details of the
  * reason behind the failure.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#aggregateoffer
+ * @see https://github.com/storacha/specs/blob/main/w3-filecoin.md#aggregateoffer
  *
  * @param {import('./types.js').InvocationConfig} conf - Configuration
  * @param {import('@web3-storage/data-segment').PieceLink} aggregate
@@ -79,7 +79,7 @@ export async function aggregateOffer(
  * `piece/offer` tasks that will retry _valid_ pieces and complete
  * asynchronously.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#aggregateaccept
+ * @see https://github.com/storacha/specs/blob/main/w3-filecoin.md#aggregateaccept
  *
  * @param {import('./types.js').InvocationConfig} conf - Configuration
  * @param {import('@web3-storage/data-segment').PieceLink} aggregate

--- a/packages/filecoin-client/src/storefront.js
+++ b/packages/filecoin-client/src/storefront.js
@@ -28,7 +28,7 @@ export const connection = connect({
  * Otherwise the task is failed and the receipt will contain details of the
  * reason behind the failure.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#filecoinoffer
+ * @see https://github.com/storacha/specs/blob/main/w3-filecoin.md#filecoinoffer
  *
  * @param {import('./types.js').InvocationConfig} conf - Configuration
  * @param {import('multiformats').UnknownLink} content
@@ -72,7 +72,7 @@ export async function filecoinOffer(
  * Otherwise the task is failed and the receipt will contain details of the
  * reason behind the failure.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#filecoinsubmit
+ * @see https://github.com/storacha/specs/blob/main/w3-filecoin.md#filecoinsubmit
  *
  * @param {import('./types.js').InvocationConfig} conf - Configuration
  * @param {import('multiformats').UnknownLink} content
@@ -116,7 +116,7 @@ export async function filecoinSubmit(
  * Otherwise the task is failed and the receipt will contain details of the
  * reason behind the failure.
  *
- * @see https://github.com/web3-storage/specs/blob/main/w3-filecoin.md#filecoinaccept
+ * @see https://github.com/storacha/specs/blob/main/w3-filecoin.md#filecoinaccept
  *
  * @param {import('./types.js').InvocationConfig} conf - Configuration
  * @param {import('multiformats').UnknownLink} content

--- a/packages/upload-api/README.md
+++ b/packages/upload-api/README.md
@@ -20,8 +20,8 @@ Coming soon!
 
 ## Contributing
 
-Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3up/issues)!
+Feel free to join in. All welcome. Please [open an issue](https://github.com/storacha/w3up/issues)!
 
 ## License
 
-Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3up/blob/main/license.md)
+Dual-licensed under [MIT + Apache 2.0](https://github.com/storacha/w3up/blob/main/license.md)

--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/upload-api"
   },
   "files": [

--- a/packages/upload-client/README.md
+++ b/packages/upload-client/README.md
@@ -5,9 +5,9 @@
 
 The `@web3-storage/upload-client` package provides the "low level" client API for uploading data to [web3.storage](https://web3.storage) using the w3up platform.
 
-Most users will be better served by the higher-level [`@web3-storage/w3up-client` package](https://github.com/web3-storage/w3up-client), which presents a simpler API and supports creating agents and registering spaces.
+Most users will be better served by the higher-level [`@web3-storage/w3up-client` package](https://github.com/storacha/w3up-client), which presents a simpler API and supports creating agents and registering spaces.
 
-If you are using this package directly instead of `w3up-client`, you will also need to use the [`@web3-storage/access` client](https://github.com/web3-storage/w3protocol/tree/main/packages/access-client) for agent and space management. The `@web3-storage/capabilities` package referenced in the examples below is a transitive dependency of both `@web3-storage/upload-client` and `@web3-storage/access`, so you shouldn't need to install it explicitly.
+If you are using this package directly instead of `w3up-client`, you will also need to use the [`@web3-storage/access` client](https://github.com/storacha/w3up/tree/main/packages/access-client) for agent and space management. The `@web3-storage/capabilities` package referenced in the examples below is a transitive dependency of both `@web3-storage/upload-client` and `@web3-storage/access`, so you shouldn't need to install it explicitly.
 
 ## Install
 
@@ -47,7 +47,7 @@ const conf = {
 }
 ```
 
-See the [`@web3-storage/access` docs](https://web3-storage.github.io/w3protocol/modules/_web3_storage_access.html) for more about creating and registering spaces.
+See the [`@web3-storage/access` docs](https://web3-storage.github.io/w3up/modules/_web3_storage_access.html) for more about creating and registering spaces.
 
 ### Uploading files
 
@@ -336,7 +336,7 @@ function add(
 ): Promise<IndexAddResponse>
 ```
 
-Register an "index" with the service. The `index` CID should be the CID of a CAR file, containing an index ad defined by [w3-index](https://github.com/w3s-project/specs/blob/main/w3-index.md).
+Register an "index" with the service. The `index` CID should be the CID of a CAR file, containing an index ad defined by [w3-index](https://github.com/storacha/specs/blob/main/w3-index.md).
 
 Required delegated capability proofs: `index/add`
 
@@ -515,7 +515,7 @@ This is the configuration for the UCAN invocation. It's values can be obtained f
 
 ### `InvocationConfigurator`
 
-A function that generates [invocation configuration](#invocationconfig) for the requested capabilities. The intention is for the client to be able to [request, on demand, delegated capabilities from an application server](https://github.com/storacha-network/w3up-examples/tree/main/delegated-upload).
+A function that generates [invocation configuration](#invocationconfig) for the requested capabilities. The intention is for the client to be able to [request, on demand, delegated capabilities from an application server](https://github.com/storacha/w3up-examples/tree/main/delegated-upload).
 
 ```ts
 interface InvocationConfigurator {
@@ -571,8 +571,8 @@ More information: [`CARMetadata`](#carmetadata)
 
 ## Contributing
 
-Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3up/issues)!
+Feel free to join in. All welcome. Please [open an issue](https://github.com/storacha/w3up/issues)!
 
 ## License
 
-Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3up/blob/main/license.md)
+Dual-licensed under [MIT + Apache 2.0](https://github.com/storacha/w3up/blob/main/license.md)

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://web3.storage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/upload-client"
   },
   "author": "Alan Shaw",

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -4,7 +4,7 @@
   <a href="https://github.com/storacha/w3up/actions/workflows/w3up-client.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/storacha/w3up/w3up-client.yml?branch=main&style=for-the-badge" /></a>
   <a href="https://discord.com/channels/806902334369824788/864892166470893588"><img src="https://img.shields.io/badge/chat-discord?style=for-the-badge&logo=discord&label=discord&logoColor=ffffff&color=7389D8" /></a>
   <a href="https://x.com/web3storage"><img alt="X Follow" src="https://img.shields.io/badge/follow-web3storage-black?style=for-the-badge&logo=x" /></a>
-  <a href="https://github.com/storacha/w3up-client/blob/main/LICENSE.md"><img alt="License: Apache-2.0 OR MIT" src="https://img.shields.io/badge/LICENSE-Apache--2.0%20OR%20MIT-yellow?style=for-the-badge" /></a>
+  <a href="https://github.com/storacha/w3up/blob/main/packages/w3up-client/LICENSE.md"><img alt="License: Apache-2.0 OR MIT" src="https://img.shields.io/badge/LICENSE-Apache--2.0%20OR%20MIT-yellow?style=for-the-badge" /></a>
 </p>
 
 ## About

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -9,7 +9,6 @@
 
 ## About
 
-
 `@web3-storage/w3up-client` is a JavaScript library that provides a convenient interface to the w3up platform, a simple "on-ramp" to the content-addressed decentralized IPFS network.
 
 This library is the user-facing "porcelain" client for interacting with w3up services from JavaScript. It wraps the lower-level [`@web3-storage/access`][access-client-github] and [`@web3-storage/upload-client`][upload-client-github] client packages, which target individual w3up services. We recommend using `w3up-client` instead of using those "plumbing" packages directly, but you may find them useful if you need more context on w3up's architecture and internals.

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -1,10 +1,10 @@
 <h1 align="center"><img src="https://bafybeia4luuns6dgymy5kau5rm7r4qzrrzg6cglpzpogussprpy42cmcn4.ipfs.w3s.link/w3up-logo.png" width="352" /></h1>
 <p align="center">The main JavaScript client for the w3up platform by <a href="https://web3.storage">https://web3.storage</a></p>
 <p align="center">
-  <a href="https://github.com/storacha-network/w3up/actions/workflows/w3up-client.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/storacha-network/w3up/w3up-client.yml?branch=main&style=for-the-badge" /></a>
+  <a href="https://github.com/storacha/w3up/actions/workflows/w3up-client.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/storacha/w3up/w3up-client.yml?branch=main&style=for-the-badge" /></a>
   <a href="https://discord.com/channels/806902334369824788/864892166470893588"><img src="https://img.shields.io/badge/chat-discord?style=for-the-badge&logo=discord&label=discord&logoColor=ffffff&color=7389D8" /></a>
   <a href="https://x.com/web3storage"><img alt="X Follow" src="https://img.shields.io/badge/follow-web3storage-black?style=for-the-badge&logo=x" /></a>
-  <a href="https://github.com/web3-storage/w3up-client/blob/main/LICENSE.md"><img alt="License: Apache-2.0 OR MIT" src="https://img.shields.io/badge/LICENSE-Apache--2.0%20OR%20MIT-yellow?style=for-the-badge" /></a>
+  <a href="https://github.com/storacha/w3up-client/blob/main/LICENSE.md"><img alt="License: Apache-2.0 OR MIT" src="https://img.shields.io/badge/LICENSE-Apache--2.0%20OR%20MIT-yellow?style=for-the-badge" /></a>
 </p>
 
 ## About
@@ -51,7 +51,7 @@ npm install @web3-storage/w3up-client
 
 [API Reference](#api)
 
-Most users' usage of `w3up-client` will be for interacting with web3.storage, a hosted storage product that developed w3up for their upload APIs. However, any user that has an implementation of w3up ([specs](https://github.com/web3-storage/specs), [protocol](https://github.com/web3-storage/w3up)) can configure `w3up-client` for their usage.
+Most users' usage of `w3up-client` will be for interacting with web3.storage, a hosted storage product that developed w3up for their upload APIs. However, any user that has an implementation of w3up ([specs](https://github.com/storacha/specs), [protocol](https://github.com/storacha/w3up)) can configure `w3up-client` for their usage.
 
 For authorization, w3up services use [ucanto][ucanto], a Remote Procedure Call (RPC) framework built around [UCAN](https://ucan.xzy), or User Controlled Authorization Networks. UCANs are a powerful capability-based authorization system that allows fine-grained sharing of permissions through a process called _delegation_ on top of [public key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography). See our [intro to UCAN blog post](https://blog.web3.storage/posts/intro-to-ucan) for an overview of UCAN.
 
@@ -89,7 +89,7 @@ flowchart TD
     C --> D(Upload to Space using Agent)
 ```
 
-All uses of `w3up-client` to upload with web3.storage follow the flow above. This section shows the most basic way to use the client to start storing data. For more complex integration options, check out the [integration options][https://github.com/web3-storage/w3up/blob/main/packages/w3up-client/README.md#integration-options] docs. For reference, check out the [API reference docs][docs] or the source code of the [`w3cli` package][w3cli-github], which uses `w3up-client` throughout.
+All uses of `w3up-client` to upload with web3.storage follow the flow above. This section shows the most basic way to use the client to start storing data. For more complex integration options, check out the [integration options][https://github.com/storacha/w3up/blob/main/packages/w3up-client/README.md#integration-options] docs. For reference, check out the [API reference docs][docs] or the source code of the [`w3cli` package][w3cli-github], which uses `w3up-client` throughout.
 
 > By you or your users registering a w3up Space via email confirmation with [web3.storage](http://web3.storage), you agree to the [Terms of Service](https://web3.storage/docs/terms/). 
 
@@ -103,9 +103,9 @@ import { create } from '@web3-storage/w3up-client'
 const client = await create()
 ```
 
-By default, clients will create a new [`Agent`][access-docs-Agent] and put it in a persistent local [`Store`](https://github.com/web3-storage/w3up/tree/main/packages/access-client) if it can't find an existing one to load (so the next time the client is initialized on the same device, it will use the same `Agent`).
+By default, clients will create a new [`Agent`][access-docs-Agent] and put it in a persistent local [`Store`](https://github.com/storacha/w3up/tree/main/packages/access-client) if it can't find an existing one to load (so the next time the client is initialized on the same device, it will use the same `Agent`).
 
-`create` accepts an optional [`ClientFactoryOptions` object][docs-ClientFactoryOptions] that can be used configured to use a non-default persistent `Store`. See the [`@web3-storage/access` docs](https://github.com/web3-storage/w3up/tree/main/packages/access-client) for more about `Store` configuration. If you'd like to bring your own Agent, you can initialize the client with your own storage [Driver](https://github.com/web3-storage/w3up/blob/main/packages/w3up-client/README.md#driver). An example would be using `Signer` from the [ucanto][ucanto] package.
+`create` accepts an optional [`ClientFactoryOptions` object][docs-ClientFactoryOptions] that can be used configured to use a non-default persistent `Store`. See the [`@web3-storage/access` docs](https://github.com/storacha/w3up/tree/main/packages/access-client) for more about `Store` configuration. If you'd like to bring your own Agent, you can initialize the client with your own storage [Driver](https://github.com/storacha/w3up/blob/main/packages/w3up-client/README.md#driver). An example would be using `Signer` from the [ucanto][ucanto] package.
 
 ```js
 import { create } from '@web3-storage/w3up-client'
@@ -138,7 +138,7 @@ Spaces can be created using the [`createSpace` client method][docs-client#create
 const space = await client.createSpace('my-awesome-space', { account })
 ```
 
-Alternatively, you can use the w3cli command [`w3 space create`](https://github.com/web3-storage/w3cli#w3-space-create-name).
+Alternatively, you can use the w3cli command [`w3 space create`](https://github.com/storacha/w3cli#w3-space-create-name).
 
 The `name` parameter is optional. If provided, it will be stored in your client's local state store and can be used to provide a friendly name for user interfaces.
 
@@ -171,7 +171,7 @@ sequenceDiagram
 
 ##### Bringing your own Agent and delegation
 
-For uses of `w3up-client` in environments where the Agent is not persisted and/or the email verification step would be prohibitive (e.g., serverless backend environment where local Store with the Agent is dropped in between runs, and going through the email verification flow isn't practical), you can manually add a delegation for access to a Space created by a different authorized agent (see the [`addSpace` client method](docs-client#addSpace)). An example (where [w3cli](https://github.com/web3-storage/w3cli) is set up with the Space that we want to delegate permissions from in our client instance):
+For uses of `w3up-client` in environments where the Agent is not persisted and/or the email verification step would be prohibitive (e.g., serverless backend environment where local Store with the Agent is dropped in between runs, and going through the email verification flow isn't practical), you can manually add a delegation for access to a Space created by a different authorized agent (see the [`addSpace` client method](docs-client#addSpace)). An example (where [w3cli](https://github.com/storacha/w3cli) is set up with the Space that we want to delegate permissions from in our client instance):
 
 ```js
 import * as Signer from '@ucanto/principal/ed25519' // Agents on Node should use Ed25519 keys
@@ -214,7 +214,7 @@ Once you've [created and registered a Space](#creating-and-registering-spaces) a
 
 Call [`uploadFile`][docs-Client#uploadFile] to upload a single file, or [`uploadDirectory`][docs-Client#uploadDirectory] to upload multiple files.
 
-`uploadFile` expects a "Blob like" input, which can be a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) or [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) when running in a browser. On node.js, see the [`filesFromPath` library](https://github.com/web3-storage/files-from-path), which can load compatible objects from the local filesystem.
+`uploadFile` expects a "Blob like" input, which can be a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) or [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) when running in a browser. On node.js, see the [`filesFromPath` library](https://github.com/storacha/files-from-path), which can load compatible objects from the local filesystem.
 
 `uploadDirectory` requires `File`-like objects instead of `Blob`s, as the file's `name` property is used to build the directory hierarchy. 
 
@@ -261,7 +261,7 @@ sequenceDiagram
 ```
 - For your backend to be scalable, you might consider using serverless workers or a queue in front of a server
 - In either case, you'll need a registered Space, and your client instance in your backend to have an Agent with a delegation from this Space
-  - (Recommended) It's likely easiest to create and register your Space using [w3cli](https://github.com/web3-storage/w3cli) rather than using `w3up-client` to do so (especially if your backend isn't persistent); you can then generate your own Agent and delegate the ability to upload to your Space using something like [this example](#bringing-your-own-agent-and-delegation)
+  - (Recommended) It's likely easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli) rather than using `w3up-client` to do so (especially if your backend isn't persistent); you can then generate your own Agent and delegate the ability to upload to your Space using something like [this example](#bringing-your-own-agent-and-delegation)
   - If your backend is persistent, you can do this or do everything in the client directly ([create Space](#creating-and-registering-spaces) and [get delegation](#delegating-from-space-to-agent))
 - After this, once your user uploads data to your backend, you can run any of the `upload` methods
 
@@ -280,7 +280,7 @@ sequenceDiagram
 - You will likely have `w3up-client` running in your end-user's client code, as well as backend code that's able to generate UCANs that delegate the ability to upload and pass them to your users (e.g., `w3up-client` running in a serverless worker)
 - For your backend to be scalable, you might consider using serverless workers or a queue in front of a server
 - As the developer, you'll need a registered Space, and your client instance in your backend to have an Agent with a delegation from this Space
-    - (Recommended) It's likely easiest to create and register your Space using [w3cli](https://github.com/web3-storage/w3cli) rather than using `w3up-client` to do so (especially if your backend isn't persistent); you can then generate your own Agent and delegate the ability to upload to your Space using something like [this example](#bringing-your-own-agent-and-delegation)
+    - (Recommended) It's likely easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli) rather than using `w3up-client` to do so (especially if your backend isn't persistent); you can then generate your own Agent and delegate the ability to upload to your Space using something like [this example](#bringing-your-own-agent-and-delegation)
   - If your backend is persistent, you can do this or do everything in the client directly ([create Space](#creating-and-registering-spaces) and [get delegation](#delegating-from-space-to-agent))
 - Your user does not need a registered Space - just an Agent with a delegation from your Space
   - `w3up-client` in the end user environment should have a unique Agent for each user, which should happen by default (since when `w3up-client` is instantiated it creates a new Agent anyway, or uses the one in local Store)
@@ -288,7 +288,7 @@ sequenceDiagram
     - In your backend, you can call [`client.createDelegation()`](docs-Client#createDelegation) passing in the Agent object from `client.agent()` in your end user's instance, and passing through `options?` params to limit the scope of the delegation (e.g., `blob/add`, `upload/add`, expiration time)
     - You can serialize this using `delegation.archive()` and send it to your user
     - The end user instance of the client should not need to call `client.login(email)`, as it is not claiming any delegations via email address (but rather getting the delegation directly from your backend)
-- Once your user receives the delegation, they can deserialize it using [`ucanto.Delegation.extract()`](https://github.com/web3-storage/ucanto/blob/c8999a59852b61549d163532a83bac62290b629d/packages/core/src/delegation.js#L399) and pass it in using `client.addSpace()`, and from there they can run any of the `upload` methods
+- Once your user receives the delegation, they can deserialize it using [`ucanto.Delegation.extract()`](https://github.com/storacha/ucanto/blob/c8999a59852b61549d163532a83bac62290b629d/packages/core/src/delegation.js#L399) and pass it in using `client.addSpace()`, and from there they can run any of the `upload` methods
     - Note that this alone does not give visibility into which of your end users are uploading what; to track this, you'll probably need them to send you that information separately (e.g., once they've run `upload` and get back a content CID, you can have them send that CID to you for tracking)
 - A code example that does this can be found below
 
@@ -371,7 +371,7 @@ sequenceDiagram
     - Doing this does take some of the UX out of your control; for instance, when web3.storage fully launches with w3up, your users will have to set up their payment methods with web3.storage
     - Note that this alone does not give visibility into which of your end users are uploading what; to track this, you'll probably need them to send you that information separately (e.g., once they've run `upload` and get back a content CID, you can have them send that CID to you for tracking)
 - There is a world of possibilities with your users "bringing their own identity" for their Space; you could explore how crypto wallet private keys, Apple Passkey, and more might map to Space DIDs and have the client use those
-- If you have code snippet(s) that works for you, please share them in a PR or [Github issue](https://github.com/web3-storage/w3up/issues) and we'll link them here!
+- If you have code snippet(s) that works for you, please share them in a PR or [Github issue](https://github.com/storacha/w3up/issues) and we'll link them here!
 
 ### Environments requiring wasm import
 
@@ -690,7 +690,7 @@ function add(
 ): Promise<IndexAddResponse>
 ```
 
-Register an "index" with the service. The `index` CID should be the CID of a CAR file, containing an index ad defined by [w3-index](https://github.com/w3s-project/specs/blob/main/w3-index.md).
+Register an "index" with the service. The `index` CID should be the CID of a CAR file, containing an index ad defined by [w3-index](https://github.com/storacha/specs/blob/main/w3-index.md).
 
 Required delegated capability proofs: `index/add`
 
@@ -827,7 +827,7 @@ The `with` field contains a resource URI, often a `did:key` URI that identifies 
 
 The optional `nb` (_nota bene_) field contains "caveats" that add supplemental information to a UCAN invocation or delegation.
 
-See [the `@web3-storage/capabilities` package](https://github.com/web3-storage/w3up/tree/main/packages/capabilities) for more information about capabilities and how they are defined in w3up services.
+See [the `@web3-storage/capabilities` package](https://github.com/storacha/w3up/tree/main/packages/capabilities) for more information about capabilities and how they are defined in w3up services.
 
 ### `CARMetadata`
 
@@ -901,7 +901,7 @@ Delegations can be serialized by calling `export()` and piping the returned `Blo
 
 ### `Driver`
 
-Storage drivers can be obtained from [`@web3-storage/access/stores`](https://github.com/web3-storage/w3up/tree/main/packages/access-client). They persist data created and managed by an agent.
+Storage drivers can be obtained from [`@web3-storage/access/stores`](https://github.com/storacha/w3up/tree/main/packages/access-client). They persist data created and managed by an agent.
 
 ### `ListResponse`
 
@@ -970,17 +970,17 @@ interface UploadListResult {
 
 ## Contributing
 
-Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3up/issues)!
+Feel free to join in. All welcome. Please [open an issue](https://github.com/storacha/w3up/issues)!
 
 ## License
 
-Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3up/blob/main/packages/w3up-client/LICENSE.md)
+Dual-licensed under [MIT + Apache 2.0](https://github.com/storacha/w3up/blob/main/packages/w3up-client/LICENSE.md)
 
-[w3cli-github]: https://github.com/web3-storage/w3cli
-[access-client-github]: https://github.com/web3-storage/w3up/tree/main/packages/access-client
-[upload-client-github]: https://github.com/web3-storage/w3up/tree/main/packages/upload-client
+[w3cli-github]: https://github.com/storacha/w3cli
+[access-client-github]: https://github.com/storacha/w3up/tree/main/packages/access-client
+[upload-client-github]: https://github.com/storacha/w3up/tree/main/packages/upload-client
 [elastic-ipfs]: https://github.com/elastic-ipfs/elastic-ipfs
-[ucanto]: https://github.com/web3-storage/ucanto
+[ucanto]: https://github.com/storacha/ucanto
 [car-spec]: https://ipld.io/specs/transport/car/
 [web3storage-docs-cars]: https://web3.storage/docs/concepts/car/
 

--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -199,7 +199,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3s-project/w3up.git",
+    "url": "https://github.com/storacha/w3up.git",
     "directory": "packages/w3up-client"
   },
   "keywords": [
@@ -214,7 +214,7 @@
   ],
   "author": "DAG House",
   "bugs": {
-    "url": "https://github.com/w3s-project/w3up/issues"
+    "url": "https://github.com/storacha/w3up/issues"
   },
   "homepage": "https://web3.storage",
   "depcheck": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,7 +46,7 @@
     "excludeExternals": true,
     "darkHighlightTheme": "github-dark",
     "navigationLinks": {
-      "Github": "https://github.com/web3-storage/w3up"
+      "Github": "https://github.com/storacha/w3up"
     },
     "customCss": "./packages/w3up-typedoc-config/static/docs.css"
   }


### PR DESCRIPTION
Fixes a _lot_ of old repo URLs e.g.`w3s-project` and `web3.storage`

Needs a follow up PR to remove references to reference docs site that does not exist: `web3-storage.github.io`

I'd like to use [jsr](https://jsr.io/) for this somehow!