### PR TITLE
feat: sharing spaces

### DIFF
--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -282,6 +282,40 @@ export class Client extends Base {
     return space
   }
 
+  /**
+   * Share an existing space with another Storacha account.
+   * Delegates access to the space to the specified email account.
+   *
+   * @typedef {object} ShareOptions
+   * @property {import("./space.js").OwnedSpace} space - The space to share.
+   * @property {import("./types.js").EmailAddress} delegateEmail - Email of the account to share the space with.
+   *
+   * @param {ShareOptions} options
+   * @returns {Promise<void>} Resolves once the space is successfully shared.
+   * @throws {Error} - Throws an error if there is an issue delegating access to the space.
+   */
+  async shareSpace(options) {
+    const { space, delegateEmail } = options
+
+    // Create a recovery for the delegate account
+    const recovery = await space.createRecovery(
+      Account.fromEmail(delegateEmail)
+    )
+
+    // Delegate space access to the delegate account
+    const result = await this.capability.access.delegate({
+      space: space.did(),
+      delegations: [recovery],
+    })
+
+    if (result.error) {
+      throw new Error(
+        `failed to share space with account ${delegateEmail}: ${result.error.message}`,
+        { cause: result.error }
+      )
+    }
+  }
+
   /* c8 ignore stop */
 
   /**

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -404,7 +404,7 @@ export const testClient = {
   shareSpace: Test.withContext({
     'should share the space with another account': async (
       assert,
-      { client: aliceClient, mail, grantAccess, connect, connection }
+      { client: aliceClient, mail, grantAccess, connection }
     ) => {
       // Step 1: Create a client for Alice and login
       const aliceEmail = 'alice@web.mail'


### PR DESCRIPTION
# Add `shareSpace()` Method to Allow Sharing Spaces with Other Accounts

## Summary

This PR introduces a new `shareSpace()` method that allows users to delegate access to an existing space with another Storacha account via email. This feature enhances collaboration by enabling multiple accounts to share access to a space, making data sharing more flexible.
By default, the following capabilities/permissions are set:
- space/* - for managing space metadata
- store/* - for managing stores
- upload/*- for registering uploads
- access/* - for re-delegating access to other devices
- filecoin/* - for submitting to the filecoin pipeline
- usage/* - for querying usage

## Changes

### New Feature: **Space Sharing**

- **Added `shareSpace()` Method**:
  - The `shareSpace()` method allows users to share an existing space with another Storacha account by delegating access to the specified email address.
  - The method takes in the following options:
    - `space`: The space to be shared, identified by its DID.
    - `delegateEmail`: The email address of the account to share the space with.
  - The sharing process involves:
    1. **Creating a delegation for the delegate account**: This ensures that the delegate has access to the space.
    2. **Delegating access**: Space access is delegated to the provided email account, allowing the delegate to manage and access the space.
  - If the sharing process fails, the method throws an error detailing the issue.


## How to Test

1. Run the following commands:
```bash
npm run build && npm run test
```
2. Ensure all existing tests pass.

3. Verify that the new test cases for the `shareSpace()` method function correctly.

## Related Issues

- [Issue #130](https://github.com/storacha/project-tracking/issues/130): Enable space sharing between accounts.

## Additional Notes

This implementation opens the door for future enhancements, such as specifying different permission levels when sharing spaces.


