### PR TITLE
feat: Generate Space proofs on the fly, on `access/claim`

### DIFF
--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -40,7 +40,6 @@ export async function requestAccess(access, account, capabilities) {
  * @param {object} opts
  * @param {string} [opts.nonce] - nonce to use for the claim
  * @param {boolean} [opts.addProofs] - whether to addProof to access agent
- * @returns
  */
 export async function claimAccess(
   access,

--- a/packages/capabilities/src/top.js
+++ b/packages/capabilities/src/top.js
@@ -9,7 +9,7 @@
  * @module
  */
 
-import { capability, URI } from '@ucanto/validator'
+import { capability, Schema } from '@ucanto/validator'
 import { equalWith } from './utils.js'
 
 /**
@@ -20,6 +20,6 @@ import { equalWith } from './utils.js'
  */
 export const top = capability({
   can: '*',
-  with: URI.match({ protocol: 'did:' }),
+  with: Schema.or(Schema.did(), Schema.literal('ucan:*')),
   derives: equalWith,
 })

--- a/packages/upload-api/src/access/claim.js
+++ b/packages/upload-api/src/access/claim.js
@@ -18,6 +18,14 @@ export const provide = (ctx) =>
 const isAccount = (principal) => principal.did().startsWith('did:mailto:')
 
 /**
+ * Returns true when the delegation has a `ucan:*` capability.
+ * @param {API.Delegation} delegation
+ * @returns boolean
+ */
+const isUcanStar = (delegation) =>
+  delegation.capabilities.some((capability) => capability.with === 'ucan:*')
+
+/**
  * @param {API.Input<Access.claim>} input
  * @param {API.AccessClaimContext} ctx
  * @returns {Promise<API.Result<API.AccessClaimSuccess, API.AccessClaimFailure>>}
@@ -38,108 +46,95 @@ export const claim = async ({ invocation }, { delegationsStorage, signer }) => {
     }
   }
 
-  // If this Agent has been confirmed by any Accounts, we'll find `*`/`ucan:*`
-  // delegations for them. But they won't have any proofs on them. They're proof
-  // of login, but don't serve to give the Agent any actual capabilities. That's
-  // our job.
-  const loginDelegations = storedDelegationsResult.ok.filter((delegation) => {
-    return delegation.capabilities.some((capability) => {
-      return capability.can === '*' && capability.with === 'ucan:*'
+  /** @type {API.Result<API.Delegation[], API.AccessClaimFailure>} */
+  const delegationsResult = await Promise.all(
+    storedDelegationsResult.ok.map(async (delegation) => {
+      // If this Agent has been confirmed by any Accounts, we'll find `*`/`ucan:*`
+      // delegations for them. But they won't have any proofs on them. They're proof
+      // of login, but don't serve to give the Agent any actual capabilities. That's
+      // our job.
+      if (isUcanStar(delegation)) {
+        // These delegations will actually have proofs granting access to the spaces.
+        // This collection also includes the attestation delegations which validate
+        // prove those delegations.
+        const sessionProofsResult = await createSessionProofsForLogin(
+          delegation,
+          delegationsStorage,
+          signer
+        )
+
+        if (sessionProofsResult.error) {
+          throw {
+            error: {
+              name: 'AccessClaimFailure',
+              message: 'error creating session proofs',
+              cause: sessionProofsResult.error,
+            },
+          }
+        }
+
+        return sessionProofsResult.ok
+      } else {
+        return [delegation]
+      }
     })
-  })
-
-  // These delegations will actually have proofs granting access to the spaces.
-  // This collection also includes the attestation delegations which validate
-  // prove those delegations.
-  const sessionProofsResult = await createSessionProofsForLogins(
-    loginDelegations,
-    delegationsStorage,
-    signer
   )
+    .then((delegations) => ({ ok: delegations.flat() }))
+    .catch((error) => ({ error }))
 
-  if (sessionProofsResult.error) {
-    return {
-      error: {
-        name: 'AccessClaimFailure',
-        message: 'error creating session proofs',
-        cause: sessionProofsResult.error,
-      },
-    }
+  if (delegationsResult.error) {
+    return delegationsResult
   }
 
   return {
     ok: {
-      delegations: delegationsResponse.encode(sessionProofsResult.ok),
+      delegations: delegationsResponse.encode(delegationsResult.ok),
     },
   }
 }
 
 /**
- * @param {API.Delegation[]} loginDelegations
+ * @param {API.Delegation} loginDelegation
  * @param {API.DelegationsStorage} delegationsStorage
  * @param {API.Signer} signer
  * @returns {Promise<API.Result<API.Delegation[], API.AccessClaimFailure>>}
  */
-async function createSessionProofsForLogins(
-  loginDelegations,
+async function createSessionProofsForLogin(
+  loginDelegation,
   delegationsStorage,
   signer
 ) {
-  const sessionProofPairsResults = await Promise.all(
-    // Each star delegation should represent an account we're logged in as.
-    // Normally there's only one, but more than one is possible and valid.
-    loginDelegations.map(async (delegation) => {
-      // These should always be Accounts (did:mailto:), but if one's not, skip
-      // it.
-      if (!isAccount(delegation.issuer)) return { ok: [] }
+  // These should always be Accounts (did:mailto:), but if one's not, skip it.
+  if (!isAccount(loginDelegation.issuer)) return { ok: [] }
 
-      const accountDelegationsResult = await delegationsStorage.find({
-        audience: delegation.issuer.did(),
-      })
+  const accountDelegationsResult = await delegationsStorage.find({
+    audience: loginDelegation.issuer.did(),
+  })
 
-      if (accountDelegationsResult.error) {
-        return {
-          error: {
-            name: 'AccessClaimFailure',
-            message: 'error finding delegations',
-            cause: accountDelegationsResult.error,
-          },
-        }
-      }
-
-      return {
-        ok: await createSessionProofs({
-          service: signer,
-          account: delegation.issuer,
-          agent: delegation.audience,
-          facts: delegation.facts,
-          capabilities: delegation.capabilities,
-          // We include all the delegations to the account so that the agent will
-          // have delegation chains to all the delegated resources.
-          // We should actually filter out only delegations that support delegated
-          // capabilities, but for now we just include all of them since we only
-          // implement sudo access anyway.
-          delegationProofs: accountDelegationsResult.ok,
-          expiration: Infinity,
-        }),
-      }
-    })
-  )
-
-  if (sessionProofPairsResults.some((result) => result.error)) {
+  if (accountDelegationsResult.error) {
     return {
       error: {
         name: 'AccessClaimFailure',
-        message: 'error creating session proofs',
-        cause: sessionProofPairsResults.find((result) => result.error),
+        message: 'error finding delegations',
+        cause: accountDelegationsResult.error,
       },
     }
   }
 
   return {
-    ok: sessionProofPairsResults.flatMap((result) =>
-      // result.ok is always present here, but TS-in-JS can't tell that.
-      result.ok ? result.ok : []
-    ),
+    ok: await createSessionProofs({
+      service: signer,
+      account: loginDelegation.issuer,
+      agent: loginDelegation.audience,
+      facts: loginDelegation.facts,
+      capabilities: loginDelegation.capabilities,
+      // We include all the delegations to the account so that the agent will
+      // have delegation chains to all the delegated resources.
+      // We should actually filter out only delegations that support delegated
+      // capabilities, but for now we just include all of them since we only
+      // implement sudo access anyway.
+      delegationProofs: accountDelegationsResult.ok,
+      expiration: Infinity,
+    }),
   }
 }

--- a/packages/upload-api/src/access/claim.js
+++ b/packages/upload-api/src/access/claim.js
@@ -2,6 +2,7 @@ import * as Server from '@ucanto/server'
 import * as Access from '@web3-storage/capabilities/access'
 import * as API from '../types.js'
 import * as delegationsResponse from '../utils/delegations-response.js'
+import { createSessionProofs } from './confirm.js'
 
 /**
  * @param {API.AccessClaimContext} ctx
@@ -10,28 +11,135 @@ export const provide = (ctx) =>
   Server.provide(Access.claim, (input) => claim(input, ctx))
 
 /**
+ * Checks if the given Principal is an Account.
+ * @param {API.Principal} principal
+ * @returns {principal is API.Principal<API.DID<'mailto'>>}
+ */
+const isAccount = (principal) => principal.did().startsWith('did:mailto:')
+
+/**
  * @param {API.Input<Access.claim>} input
  * @param {API.AccessClaimContext} ctx
  * @returns {Promise<API.Result<API.AccessClaimSuccess, API.AccessClaimFailure>>}
  */
-export const claim = async (
-  { invocation },
-  { delegationsStorage: delegations }
-) => {
+export const claim = async ({ invocation }, { delegationsStorage, signer }) => {
   const claimedAudience = invocation.capabilities[0].with
-  const claimedResult = await delegations.find({ audience: claimedAudience })
-  if (claimedResult.error) {
+  const storedDelegationsResult = await delegationsStorage.find({
+    audience: claimedAudience,
+  })
+
+  if (storedDelegationsResult.error) {
     return {
       error: {
         name: 'AccessClaimFailure',
         message: 'error finding delegations',
-        cause: claimedResult.error,
+        cause: storedDelegationsResult.error,
       },
     }
   }
+
+  // If this Agent has been confirmed by any Accounts, we'll find `*`/`ucan:*`
+  // delegations for them. But they won't have any proofs on them. They're proof
+  // of login, but don't serve to give the Agent any actual capabilities. That's
+  // our job.
+  const loginDelegations = storedDelegationsResult.ok.filter((delegation) => {
+    return delegation.capabilities.some((capability) => {
+      return capability.can === '*' && capability.with === 'ucan:*'
+    })
+  })
+
+  // These delegations will actually have proofs granting access to the spaces.
+  // This collection also includes the attestation delegations which validate
+  // prove those delegations.
+  const sessionProofsResult = await createSessionProofsForLogins(
+    loginDelegations,
+    delegationsStorage,
+    signer
+  )
+
+  if (sessionProofsResult.error) {
+    return {
+      error: {
+        name: 'AccessClaimFailure',
+        message: 'error creating session proofs',
+        cause: sessionProofsResult.error,
+      },
+    }
+  }
+
   return {
     ok: {
-      delegations: delegationsResponse.encode(claimedResult.ok),
+      delegations: delegationsResponse.encode(sessionProofsResult.ok),
     },
+  }
+}
+
+/**
+ * @param {API.Delegation[]} loginDelegations
+ * @param {API.DelegationsStorage} delegationsStorage
+ * @param {API.Signer} signer
+ * @returns {Promise<API.Result<API.Delegation[], API.AccessClaimFailure>>}
+ */
+async function createSessionProofsForLogins(
+  loginDelegations,
+  delegationsStorage,
+  signer
+) {
+  const sessionProofPairsResults = await Promise.all(
+    // Each star delegation should represent an account we're logged in as.
+    // Normally there's only one, but more than one is possible and valid.
+    loginDelegations.map(async (delegation) => {
+      // These should always be Accounts (did:mailto:), but if one's not, skip
+      // it.
+      if (!isAccount(delegation.issuer)) return { ok: [] }
+
+      const accountDelegationsResult = await delegationsStorage.find({
+        audience: delegation.issuer.did(),
+      })
+
+      if (accountDelegationsResult.error) {
+        return {
+          error: {
+            name: 'AccessClaimFailure',
+            message: 'error finding delegations',
+            cause: accountDelegationsResult.error,
+          },
+        }
+      }
+
+      return {
+        ok: await createSessionProofs({
+          service: signer,
+          account: delegation.issuer,
+          agent: delegation.audience,
+          facts: delegation.facts,
+          capabilities: delegation.capabilities,
+          // We include all the delegations to the account so that the agent will
+          // have delegation chains to all the delegated resources.
+          // We should actually filter out only delegations that support delegated
+          // capabilities, but for now we just include all of them since we only
+          // implement sudo access anyway.
+          delegationProofs: accountDelegationsResult.ok,
+          expiration: Infinity,
+        }),
+      }
+    })
+  )
+
+  if (sessionProofPairsResults.some((result) => result.error)) {
+    return {
+      error: {
+        name: 'AccessClaimFailure',
+        message: 'error creating session proofs',
+        cause: sessionProofPairsResults.find((result) => result.error),
+      },
+    }
+  }
+
+  return {
+    ok: sessionProofPairsResults.flatMap((result) =>
+      // result.ok is always present here, but TS-in-JS can't tell that.
+      result.ok ? result.ok : []
+    ),
   }
 }

--- a/packages/upload-api/src/access/claim.js
+++ b/packages/upload-api/src/access/claim.js
@@ -23,7 +23,7 @@ const isAccount = (principal) => principal.did().startsWith('did:mailto:')
  * @param {API.Delegation} delegation
  * @returns boolean
  */
-const isUcanStar = (delegation) =>
+const isUCANStar = (delegation) =>
   delegation.capabilities.some((capability) => capability.with === 'ucan:*')
 
 /**
@@ -76,7 +76,7 @@ export const claim = async ({ invocation }, { delegationsStorage, signer }) => {
     // Ignore attestations of delegations we don't have.
     const attestedCid = attestCap.nb.proof
     const attestedDelegation = delegationsToReturnByCid[attestedCid.toString()]
-    if (!(attestedDelegation && isUcanStar(attestedDelegation))) continue
+    if (!(attestedDelegation && isUCANStar(attestedDelegation))) continue
 
     // Create new session proofs for the attested delegation.
     const sessionProofsResult = await createSessionProofsForLogin(

--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -57,6 +57,8 @@ export async function confirm({ capability, invocation }, ctx) {
     return delegationsResult
   }
 
+  // Create session proofs, but containing no Space proofs. We'll store these,
+  // and generate the Space proofs on access/claim.
   const [delegation, attestation] = await createSessionProofs({
     service: ctx.signer,
     account,
@@ -72,16 +74,11 @@ export async function confirm({ capability, invocation }, ctx) {
       },
     ],
     capabilities,
-    // We include all the delegations to the account so that the agent will
-    // have delegation chains to all the delegated resources.
-    // We should actually filter out only delegations that support delegated
-    // capabilities, but for now we just include all of them since we only
-    // implement sudo access anyway.
-    delegationProofs: delegationsResult.ok,
+    delegationProofs: [],
     expiration: Infinity,
   })
 
-  // Store the delegations so that they can be pulled with access/claim.
+  // Store the delegations so that they can be pulled during access/claim.
   // Since there is no invocation that contains these delegations, don't pass
   // a `cause` parameter.
   // TODO: we should invoke access/delegate here rather than interacting with

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -31,7 +31,6 @@ import type {
 } from '@ucanto/interface'
 import type { ProviderInput, ConnectionView } from '@ucanto/server'
 
-import { Signer as EdSigner } from '@ucanto/principal/ed25519'
 import { StorefrontService } from '@web3-storage/filecoin-api/types'
 import { ServiceContext as FilecoinServiceContext } from '@web3-storage/filecoin-api/storefront/api'
 import { DelegationsStorage as Delegations } from './types/delegations.js'
@@ -398,17 +397,16 @@ export type UploadServiceContext = ConsumerServiceContext &
   SpaceServiceContext &
   RevocationServiceContext &
   ConcludeServiceContext & {
-    signer: EdSigner.Signer
+    signer: Signer
     uploadTable: UploadTable
   }
 
 export interface AccessClaimContext {
-  signer: EdSigner.Signer
+  signer: Signer
   delegationsStorage: Delegations
 }
 
 export interface AccessServiceContext extends AccessClaimContext, AgentContext {
-  signer: EdSigner.Signer
   email: Email
   url: URL
   provisionsStorage: Provisions
@@ -416,17 +414,17 @@ export interface AccessServiceContext extends AccessClaimContext, AgentContext {
 }
 
 export interface ConsumerServiceContext {
-  signer: EdSigner.Signer
+  signer: Signer
   provisionsStorage: Provisions
 }
 
 export interface CustomerServiceContext {
-  signer: EdSigner.Signer
+  signer: Signer
   provisionsStorage: Provisions
 }
 
 export interface AdminServiceContext {
-  signer: EdSigner.Signer
+  signer: Signer
   uploadTable: UploadTable
   storeTable: StoreTable
 }
@@ -447,7 +445,7 @@ export interface ProviderServiceContext {
 }
 
 export interface SubscriptionServiceContext {
-  signer: EdSigner.Signer
+  signer: Signer
   provisionsStorage: Provisions
   subscriptionsStorage: SubscriptionsStorage
 }

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -403,6 +403,7 @@ export type UploadServiceContext = ConsumerServiceContext &
   }
 
 export interface AccessClaimContext {
+  signer: EdSigner.Signer
   delegationsStorage: Delegations
 }
 

--- a/packages/upload-api/test/types.ts
+++ b/packages/upload-api/test/types.ts
@@ -1,4 +1,5 @@
 import * as API from '../src/types.js'
+import assert from 'node:assert'
 
 export * from '../src/types.js'
 
@@ -19,13 +20,14 @@ export interface Assert {
     actual: Actual,
     expected: Expected,
     message?: string
-  ) => unknown
+  ) => void
   deepEqual: <Actual, Expected extends Actual>(
     actual: Actual,
     expected: Expected,
     message?: string
-  ) => unknown
-  ok: <Actual>(actual: Actual, message?: string) => unknown
+  ) => void
+  ok: <Actual>(actual: Actual, message?: string) => void
+  rejects: typeof assert.rejects
 }
 
 export type Test = (assert: Assert, context: TestContext) => unknown


### PR DESCRIPTION
The bulk of the work for https://github.com/storacha/project-tracking/issues/125.

This together with [`w3ui` calling `access/claim` on page load](https://github.com/storacha/w3ui/pull/644) will make new spaces appear on the page without logging out.

---

## The Strategy

* On `access/confirm`, where we previously created a `*`/`ucan:*` delegation with proofs for each space, we now create one with no proofs. This delegation technically provides no capability, but serves as a signal in `access/claim`.
* During `access/claim`, we look for the Agent's `*`/`ucan:*` delegations in the store, and translate them on the fly into ones containing proofs for the relevant spaces. This is legitimate, because `*`/`ucan:*` means the Agent has been granted access to anything the Account can do, it just doesn't have the proofs that Account can do anything yet. We're just putting 2 and 2 together.

## Remaining

* [x] We don't validate the `*`/`ucan:*` delegation before recreating it. If `access/confirm` doesn't create an attestation, `access/claim` will still happily make one for its new delegation. That's a (minor?) security issue. If the delegation is in our store, we can probably trust it, but better to care about the attestation.
* [x] Tests for all of this.