### PR TITLE
refactor: De-deprecate `AgentData`'s `addSpace()`

### DIFF
--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -112,7 +112,6 @@ export class AgentData {
   }
 
   /**
-   * @deprecated
    * @param {import('@ucanto/interface').DID} did
    * @param {import('./types.js').SpaceMeta} meta
    * @param {import('@ucanto/interface').Delegation} [proof]


### PR DESCRIPTION
This was deprecated in https://github.com/storacha/w3up/pull/433, but it's still what we use, and no clear migration path was given.

@alanshaw Do you remember what the plan was? Should we do this and reverse it, or is there a better way we should write down?