### PR TITLE
fix(filecoin-api): parallel put to piece accept queue

### DIFF
--- a/packages/filecoin-api/src/aggregator/events.js
+++ b/packages/filecoin-api/src/aggregator/events.js
@@ -246,7 +246,7 @@ export const handleAggregateInsertToPieceAcceptQueue = async (
 
       return { ok: {} }
     },
-    { concurrency: 25 }
+    { concurrency: 10 }
   )
   for (const r of results) {
     if (r.error) return r


### PR DESCRIPTION
Simply uses `p-map` to put items to the queue in parallel and speed up execution time of this lambda (which is currently timing out).