### PR TITLE
fix(test): await promise and check error

### DIFF
--- a/packages/upload-api/test/access-client-agent.js
+++ b/packages/upload-api/test/access-client-agent.js
@@ -380,7 +380,10 @@ export const test = {
     )
 
     // deviceCheater shouldn't have access to the space
-    deviceCheater.setCurrentSpace(space.did())
+    await assert.rejects(deviceCheater.setCurrentSpace(space.did()), {
+      name: 'Error',
+      message: `Agent has no proofs for ${space.did()}.`,
+    })
 
     // deviceCheater tries to craft a delegation to gain access to the account
     const unattestedDelegation = await Top.top.delegate({


### PR DESCRIPTION
**Resolve ESLint Promise Handling Error**

Fixed the ESLint error by using `assert.rejects` to handle the promise returned by `deviceCheater.setCurrentSpace`. This ensures that the promise is properly managed and the test checks for expected rejections, addressing the ESLint rule that requires promises to be awaited, handled with `.catch`, or explicitly ignored.