### PR TITLE
fix: configure max pieces

### DIFF
--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -149,7 +149,7 @@
     "dev": "tsc --build --watch",
     "check": "tsc --build",
     "lint": "tsc --build && eslint '**/*.{js,ts}'",
-    "test": "mocha --bail --timeout 100s -n no-warnings -n experimental-vm-modules -n experimental-fetch test/**/*.spec.js",
+    "test": "mocha --bail --timeout 10s -n no-warnings -n experimental-vm-modules -n experimental-fetch test/**/*.spec.js",
     "test-watch": "pnpm build && mocha --bail --timeout 10s --watch --parallel -n no-warnings -n experimental-vm-modules -n experimental-fetch --watch-files src,test",
     "coverage": "c8 -r text -r html npm run test"
   },

--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -149,7 +149,7 @@
     "dev": "tsc --build --watch",
     "check": "tsc --build",
     "lint": "tsc --build && eslint '**/*.{js,ts}'",
-    "test": "mocha --bail --timeout 10s -n no-warnings -n experimental-vm-modules -n experimental-fetch test/**/*.spec.js",
+    "test": "mocha --bail --timeout 100s -n no-warnings -n experimental-vm-modules -n experimental-fetch test/**/*.spec.js",
     "test-watch": "pnpm build && mocha --bail --timeout 10s --watch --parallel -n no-warnings -n experimental-vm-modules -n experimental-fetch --watch-files src,test",
     "coverage": "c8 -r text -r html npm run test"
   },

--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -189,6 +189,7 @@
       "project": "./tsconfig.json"
     },
     "env": {
+      "browser": true,
       "mocha": true
     },
     "ignorePatterns": [

--- a/packages/filecoin-api/src/aggregator/api.ts
+++ b/packages/filecoin-api/src/aggregator/api.ts
@@ -328,6 +328,13 @@ export interface AggregateConfig {
   minUtilizationFactor: number
   prependBufferedPieces?: BufferedPiece[]
   hasher?: DataSegmentAPI.SyncMultihashHasher<DataSegmentAPI.SHA256_CODE>
+  /**
+   * The maximum number of pieces per aggregate. If set, it takes precedence
+   * over `minAggregateSize` because it is typically a hard limit related to
+   * the number of hashes that can be performed within the maximum lambda
+   * execution time limit.
+   */
+  maxAggregatePieces?: number
 }
 
 // Enums

--- a/packages/filecoin-api/src/aggregator/events.js
+++ b/packages/filecoin-api/src/aggregator/events.js
@@ -117,6 +117,7 @@ export const handleBufferQueueMessage = async (context, records) => {
     minUtilizationFactor: context.config.minUtilizationFactor,
     prependBufferedPieces: context.config.prependBufferedPieces,
     hasher: context.config.hasher,
+    maxAggregatePieces: context.config.maxAggregatePieces,
   })
 
   // Store buffered pieces if not enough to do aggregate and re-queue them


### PR DESCRIPTION
In lambda we only have 15 minutes max to execute. Without significant changes to the way the library works there is only so many hashes we can perform.

This PR adds a new configuration parameter `maxAggregatePieces` which serves to restrict the maximum number of hashes the aggregator will have to perform to build an aggregate. This will be tuned to be as high as possible to allow execution within the time bounds. The PR also adds logging in order to determine this limit.