### PR TITLE
fix: publish location claim to content claims service

### DIFF
--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -202,7 +202,7 @@
     "@web3-storage/access": "workspace:^",
     "@web3-storage/blob-index": "workspace:^",
     "@web3-storage/capabilities": "workspace:^",
-    "@web3-storage/content-claims": "^5.1.0",
+    "@web3-storage/content-claims": "^5.1.3",
     "@web3-storage/did-mailto": "workspace:^",
     "@web3-storage/filecoin-api": "workspace:^",
     "multiformats": "^12.1.2",

--- a/packages/upload-api/src/blob/accept.js
+++ b/packages/upload-api/src/blob/accept.js
@@ -55,7 +55,7 @@ export function blobAcceptProvider(context) {
       })
 
       // Publish this claim to the content claims service
-      const pubClaim = await publishLocationClaim(context, { space, digest, location: createUrl.ok })
+      const pubClaim = await publishLocationClaim(context, { space, digest, size: blob.size, location: createUrl.ok })
       if (pubClaim.error) {
         return pubClaim
       }
@@ -146,9 +146,9 @@ export const poll = async (context, receipt) => {
 
 /**
  * @param {API.ClaimsClientContext} ctx
- * @param {{ space: API.SpaceDID, digest: API.MultihashDigest, location: API.URI }} params
+ * @param {{ space: API.SpaceDID, digest: API.MultihashDigest, size: number, location: API.URI }} params
  */
-const publishLocationClaim = async (ctx, { digest, location }) => {
+const publishLocationClaim = async (ctx, { digest, size, location }) => {
   const { invocationConfig, connection } = ctx.claimsService
   const { issuer, audience, with: resource, proofs } = invocationConfig
   const res = await Assert.location
@@ -156,7 +156,11 @@ const publishLocationClaim = async (ctx, { digest, location }) => {
       issuer,
       audience,
       with: resource,
-      nb: { content: { digest: digest.bytes }, location: [location] },
+      nb: {
+        content: { digest: digest.bytes },
+        location: [location],
+        range: { offset: 0, length: size }
+      },
       expiration: Infinity,
       proofs,
     })

--- a/packages/upload-api/src/blob/accept.js
+++ b/packages/upload-api/src/blob/accept.js
@@ -55,7 +55,7 @@ export function blobAcceptProvider(context) {
       })
 
       // Publish this claim to the content claims service
-      const pubClaim = await publishLocationClaim(context, { digest, location: createUrl.ok })
+      const pubClaim = await publishLocationClaim(context, { space, digest, location: createUrl.ok })
       if (pubClaim.error) {
         return pubClaim
       }
@@ -146,7 +146,7 @@ export const poll = async (context, receipt) => {
 
 /**
  * @param {API.ClaimsClientContext} ctx
- * @param {{ digest: API.MultihashDigest, location: API.URI }} params
+ * @param {{ space: API.SpaceDID, digest: API.MultihashDigest, location: API.URI }} params
  */
 const publishLocationClaim = async (ctx, { digest, location }) => {
   const { invocationConfig, connection } = ctx.claimsService

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -203,7 +203,7 @@ import { StorageGetError } from './types/storage.js'
 import { AllocationsStorage, BlobsStorage, BlobAddInput } from './types/blob.js'
 export type { AllocationsStorage, BlobsStorage, BlobAddInput }
 import { IPNIService, IndexServiceContext } from './types/index.js'
-import { ClaimsClientConfig } from './types/content-claims.js'
+import { ClaimsClientConfig, ClaimsClientContext } from './types/content-claims.js'
 import { Claim } from '@web3-storage/content-claims/client/api'
 export type {
   IndexServiceContext,
@@ -378,7 +378,7 @@ export type BlobServiceContext = SpaceServiceContext & {
   getServiceConnection: () => ConnectionView<Service>
 }
 
-export type W3ServiceContext = SpaceServiceContext & {
+export type W3ServiceContext = SpaceServiceContext & ClaimsClientContext & {
   /**
    * Service signer
    */

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -366,7 +366,7 @@ export interface W3sService {
   }
 }
 
-export type BlobServiceContext = SpaceServiceContext & {
+export type BlobServiceContext = SpaceServiceContext & ClaimsClientContext & {
   /**
    * Service signer
    */

--- a/packages/w3up-client/test/capability/space.test.js
+++ b/packages/w3up-client/test/capability/space.test.js
@@ -142,7 +142,7 @@ export const SpaceClient = Test.withContext({
         assert.equal(egressRecord.bytes, car.size, 'bytes should be the same')
         assert.equal(
           new Date(egressRecord.servedAt).getTime(),
-          Math.floor(new Date(egressData.servedAt).getTime() / 1000) * 1000,
+          Math.floor(new Date(egressData.servedAt).getTime() / 1000),
           'servedAt should be the same'
         )
         assert.ok(egressRecord.cause.toString(), 'cause should be a link')
@@ -252,7 +252,7 @@ export const SpaceClient = Test.withContext({
         assert.equal(egressRecord.bytes, car.size, 'bytes should be the same')
         assert.equal(
           new Date(egressRecord.servedAt).getTime(),
-          Math.floor(new Date(egressData.servedAt).getTime() / 1000) * 1000,
+          Math.floor(new Date(egressData.servedAt).getTime() / 1000),
           'servedAt should be the same'
         )
         assert.ok(egressRecord.cause.toString(), 'cause should be a link')
@@ -364,7 +364,7 @@ export const SpaceClient = Test.withContext({
           assert.equal(egressRecord.bytes, car.size, 'bytes should be the same')
           assert.equal(
             new Date(egressRecord.servedAt).getTime(),
-            Math.floor(new Date(egressData.servedAt).getTime() / 1000) * 1000,
+            Math.floor(new Date(egressData.servedAt).getTime() / 1000),
             'servedAt should be the same'
           )
           assert.ok(egressRecord.cause.toString(), 'cause should be a link')
@@ -476,7 +476,7 @@ export const SpaceClient = Test.withContext({
           assert.equal(egressRecord.bytes, car.size, 'bytes should be the same')
           assert.equal(
             new Date(egressRecord.servedAt).getTime(),
-            Math.floor(new Date(egressData.servedAt).getTime() / 1000) * 1000,
+            Math.floor(new Date(egressData.servedAt).getTime() / 1000),
             'servedAt should be the same'
           )
           assert.ok(egressRecord.cause.toString(), 'cause should be a link')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,8 +450,8 @@ importers:
         specifier: workspace:^
         version: link:../capabilities
       '@web3-storage/content-claims':
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.1.3
+        version: 5.1.3
       '@web3-storage/did-mailto':
         specifier: workspace:^
         version: link:../did-mailto
@@ -2521,8 +2521,8 @@ packages:
   '@web3-storage/content-claims@5.0.0':
     resolution: {integrity: sha512-HJFRFsR0qHCe0cOERsb3AjAxxzohYMMoIWaGJgrShDycnl6yqXHrGcdua1BWUDu5pmvKzwD9D7VmI8aSfrCcRA==}
 
-  '@web3-storage/content-claims@5.1.0':
-    resolution: {integrity: sha512-3VStFKoeieRpRU7brFjKTsAuAffQzYDIZ8F3Gh0+niw+MgzBK72osW+fftdquT8neWir34Ndu3mBUKKJ3ck1RQ==}
+  '@web3-storage/content-claims@5.1.3':
+    resolution: {integrity: sha512-X+Cpm+EmGuEvFyM8oX1NqsBkuSje836B72yuvnVmgd80XPt+McpOhM6ko7rfs9Dx9UmpiZq+998jlvBhg2W5ZA==}
 
   '@web3-storage/data-segment@4.0.0':
     resolution: {integrity: sha512-AnNyJp3wHMa7LBzguQzm4rmXSi8vQBz4uFs+jiXnSNtLR5dAqHfhMvi9XdWonWPYvxNvT5ZhYCSF0mpDjymqKg==}
@@ -9759,14 +9759,14 @@ snapshots:
       carstream: 2.1.0
       multiformats: 13.1.0
 
-  '@web3-storage/content-claims@5.1.0':
+  '@web3-storage/content-claims@5.1.3':
     dependencies:
       '@ucanto/client': 9.0.1
       '@ucanto/interface': 10.0.1
       '@ucanto/server': 10.0.0
       '@ucanto/transport': 9.1.1
       carstream: 2.1.0
-      multiformats: 13.1.0
+      multiformats: 13.3.0
 
   '@web3-storage/data-segment@4.0.0':
     dependencies:


### PR DESCRIPTION
Big oversight here, although I think the original intention was to have the client publish these so perhaps not.

Anyways, since no location claims are being published the gateway cannot fetch an index and serve bytes quickly. It has to get a location claim for every single block using the old dynamodb. Being able to use the index will result in a speed increase for serving content via the gateway.

Depends on https://github.com/storacha/content-claims/pull/74 for passing tests.