### PR TITLE
fix(egressRecord): Remove unnecessary multiplication for ts conversion

### DIFF
--- a/packages/capabilities/src/space.js
+++ b/packages/capabilities/src/space.js
@@ -87,7 +87,7 @@ export const egressRecord = capability({
     resource: Schema.link(),
     /** Amount of bytes served. */
     bytes: Schema.integer().greaterThan(0),
-    /** Timestamp of the event in seconds after Unix epoch. */
+    /** Timestamp of the event in milliseconds after Unix epoch. */
     servedAt: Schema.integer().greaterThan(-1),
   }),
   derives: equalWith,

--- a/packages/upload-api/src/space/record.js
+++ b/packages/upload-api/src/space/record.js
@@ -33,7 +33,7 @@ const egressRecord = async ({ capability, invocation }, context) => {
     // Number of bytes that were served.
     capability.nb.bytes,
     // Date and time when the resource was served.
-    new Date(capability.nb.servedAt * 1000),
+    new Date(capability.nb.servedAt),
     // Link to the invocation that caused the egress traffic.
     invocation.cid
   )


### PR DESCRIPTION
### Context
This PR fixes the handling of the `servedAt` timestamp in the `packages/upload-api/src/space/record.js` file. 

The previous implementation included a multiplication by 1000, assuming a conversion from seconds to milliseconds was necessary. This change removes the conversion.