### PR TITLE
feat!: content serve authorization

### DIFF
--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -131,16 +131,6 @@ export type UsageReport = InferInvokedCapability<typeof UsageCaps.report>
 export type UsageReportSuccess = Record<ProviderDID, UsageData>
 export type UsageReportFailure = Ucanto.Failure
 
-export type EgressRecord = InferInvokedCapability<typeof SpaceCaps.egressRecord>
-export type EgressRecordSuccess = {
-  space: SpaceDID
-  resource: UnknownLink
-  bytes: number
-  servedAt: ISO8601Date
-  cause: UnknownLink
-}
-export type EgressRecordFailure = ConsumerNotFound | Ucanto.Failure
-
 export interface UsageData {
   /** Provider the report concerns, e.g. `did:web:web3.storage` */
   provider: ProviderDID
@@ -284,6 +274,18 @@ export type RateLimitListFailure = Ucanto.Failure
 // Space
 export type Space = InferInvokedCapability<typeof SpaceCaps.space>
 export type SpaceInfo = InferInvokedCapability<typeof SpaceCaps.info>
+export type SpaceContentServe = InferInvokedCapability<
+  typeof SpaceCaps.contentServe
+>
+export type EgressRecord = InferInvokedCapability<typeof SpaceCaps.egressRecord>
+export type EgressRecordSuccess = {
+  space: SpaceDID
+  resource: UnknownLink
+  bytes: number
+  servedAt: ISO8601Date
+  cause: UnknownLink
+}
+export type EgressRecordFailure = ConsumerNotFound | Ucanto.Failure
 
 // filecoin
 export interface DealMetadata {
@@ -895,6 +897,8 @@ export type ServiceAbilityArray = [
   ProviderAdd['can'],
   Space['can'],
   SpaceInfo['can'],
+  SpaceContentServe['can'],
+  EgressRecord['can'],
   Upload['can'],
   UploadAdd['can'],
   UploadGet['can'],

--- a/packages/filecoin-api/src/aggregator/events.js
+++ b/packages/filecoin-api/src/aggregator/events.js
@@ -229,7 +229,10 @@ export const handleAggregateInsertToPieceAcceptQueue = async (
   // TODO: Batch per a maximum to queue
   const results = await map(
     pieces,
-    /** @returns {Promise<import('@ucanto/interface').Result<import('@ucanto/interface').Unit, RangeError|import('../types.js').QueueAddError>>} */
+    /**
+     * @param piece
+     * @returns {Promise<import('@ucanto/interface').Result<import('@ucanto/interface').Unit, RangeError|import('../types.js').QueueAddError>>}
+     */
     async piece => {
       const inclusionProof = aggregateBuilder.resolveProof(piece.link)
       if (inclusionProof.error) return inclusionProof

--- a/packages/filecoin-api/test/context/service.js
+++ b/packages/filecoin-api/test/context/service.js
@@ -13,7 +13,6 @@ import * as API from '../../src/types.js'
 
 import { validateAuthorization } from '../utils.js'
 import { mockService } from './mocks.js'
-import { Access } from '@web3-storage/capabilities'
 
 export { getStoreImplementations } from './store-implementations.js'
 export { getQueueImplementations } from './queue-implementations.js'
@@ -234,16 +233,6 @@ export function getMockService() {
     assert: {
       equals: Server.provide(
         Assert.equals,
-        async ({ capability, invocation }) => {
-          return {
-            ok: {},
-          }
-        }
-      ),
-    },
-    access: {
-      delegate: Server.provide(
-        Access.delegate,
         async ({ capability, invocation }) => {
           return {
             ok: {},

--- a/packages/filecoin-api/test/context/service.js
+++ b/packages/filecoin-api/test/context/service.js
@@ -13,6 +13,7 @@ import * as API from '../../src/types.js'
 
 import { validateAuthorization } from '../utils.js'
 import { mockService } from './mocks.js'
+import { Access } from '@web3-storage/capabilities'
 
 export { getStoreImplementations } from './store-implementations.js'
 export { getQueueImplementations } from './queue-implementations.js'
@@ -233,6 +234,16 @@ export function getMockService() {
     assert: {
       equals: Server.provide(
         Assert.equals,
+        async ({ capability, invocation }) => {
+          return {
+            ok: {},
+          }
+        }
+      ),
+    },
+    access: {
+      delegate: Server.provide(
+        Access.delegate,
         async ({ capability, invocation }) => {
           return {
             ok: {},

--- a/packages/upload-api/src/access/claim.js
+++ b/packages/upload-api/src/access/claim.js
@@ -13,6 +13,7 @@ export const provide = (ctx) =>
 
 /**
  * Checks if the given Principal is an Account.
+ *
  * @param {API.Principal} principal
  * @returns {principal is API.Principal<API.DID<'mailto'>>}
  */
@@ -20,6 +21,7 @@ const isAccount = (principal) => principal.did().startsWith('did:mailto:')
 
 /**
  * Returns true when the delegation has a `ucan:*` capability.
+ *
  * @param {API.Delegation} delegation
  * @returns boolean
  */

--- a/packages/upload-api/src/lib.js
+++ b/packages/upload-api/src/lib.js
@@ -147,8 +147,8 @@ export const execute = async (agent, input) => {
  * a receipt it will return receipt without running invocation.
  *
  * @template {Record<string, any>} S
- * @param {Types.Invocation} invocation
  * @param {Agent<S>} agent
+ * @param {Types.Invocation} invocation
  */
 export const run = async (agent, invocation) => {
   const cached = await agent.context.agentStore.receipts.get(invocation.link())

--- a/packages/upload-api/test/helpers/utils.js
+++ b/packages/upload-api/test/helpers/utils.js
@@ -43,6 +43,7 @@ export const w3Signer = ed25519.parse(
 )
 export const w3 = w3Signer.withDID('did:web:test.web3.storage')
 
+/** did:key:z6MkuKJgV8DKxiAF5oaUcT8ckg8kZUoBe6yavSLnHn5ZgyAP */
 export const gatewaySigner = ed25519.parse(
   'MgCaNpGXCEX0+BxxE4SjSStrxU9Ru/Im+HGNQ/JJx3lDoI+0B3NWjWW3G8OzjbazZjanjM3kgfcZbvpyxv20jHtmcTtg='
 )

--- a/packages/upload-api/test/helpers/utils.js
+++ b/packages/upload-api/test/helpers/utils.js
@@ -37,6 +37,7 @@ export const mallory = ed25519.parse(
   'MgCYtH0AvYxiQwBG6+ZXcwlXywq9tI50G2mCAUJbwrrahkO0B0elFYkl3Ulf3Q3A/EvcVY0utb4etiSE8e6pi4H0FEmU='
 )
 
+/** did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z */
 export const w3Signer = ed25519.parse(
   'MgCYKXoHVy7Vk4/QjcEGi+MCqjntUiasxXJ8uJKY0qh11e+0Bs8WsdqGK7xothgrDzzWD0ME7ynPjz2okXDh8537lId8='
 )

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -258,7 +258,7 @@ export class Client extends Base {
    * User can skip the Content Serve authorization by setting the `skipContentServeAuthorization` option to `true`.
    *
    * @typedef {object} SpaceCreateOptions
-   * @property {boolean} [skipContentServeAuthorization] - Whether to skip the Content Serve authorization.
+   * @property {boolean} [skipContentServeAuthorization] - Whether to skip the Content Serve authorization. It means that the content of the space will not be served by any Content Serve Service.
    * @property {`did:${string}:${string}`[]} [authorizeContentServeServices] - The DID Key or DID Web of the Content Serve Service to authorize to serve content from the created space.
    * @property {import('./types.js').ConnectionView<import('./types.js').ContentServeService>} [authorizeContentServeServices.connection] - The connection to the Content Serve Service that will handle, validate, and store the access/delegate UCAN invocation.
    * @property {Account.Account} [account] - The account configured as the recovery account for the space.
@@ -271,6 +271,9 @@ export class Client extends Base {
   async createSpace(name, options) {
     const space = await this._agent.createSpace(name)
 
+    // Save the space to authorize the client to use the space
+    await space.save()
+
     const account = options.account
     if (account) {
       // Provision the account with the space
@@ -281,9 +284,6 @@ export class Client extends Base {
           { cause: provisionResult.error }
         )
       }
-
-      // Save the space to authorize the client to use the space
-      await space.save()
 
       // Create a recovery for the account
       const recovery = await space.createRecovery(account.did())
@@ -379,7 +379,7 @@ export class Client extends Base {
 
       if (verificationResult.out.error) {
         throw new Error(
-          `failed to publish delegation for audience ${options.audience} to the content serve service: ${verificationResult.out.error.message}`,
+          `failed to publish delegation for audience ${options.audience}: ${verificationResult.out.error.message}`,
           {
             cause: verificationResult.out.error,
           }

--- a/packages/w3up-client/src/index.js
+++ b/packages/w3up-client/src/index.js
@@ -44,4 +44,7 @@ export async function create(options = {}) {
   return new Client(data, options)
 }
 
+export const authorizeContentServe =
+  Client.prototype.authorizeContentServe.bind(Client.prototype)
+
 export { Client }

--- a/packages/w3up-client/src/index.js
+++ b/packages/w3up-client/src/index.js
@@ -12,6 +12,7 @@ import { Client } from './client.js'
 export * as Result from './result.js'
 export * as Account from './account.js'
 export * from './ability.js'
+export { authorizeContentServe } from './client.js'
 
 /**
  * Create a new w3up client.
@@ -43,8 +44,5 @@ export async function create(options = {}) {
   const data = await AgentData.create({ principal }, { store })
   return new Client(data, options)
 }
-
-export const authorizeContentServe =
-  Client.prototype.authorizeContentServe.bind(Client.prototype)
 
 export { Client }

--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -1,5 +1,8 @@
 import { type Driver } from '@web3-storage/access/drivers/types'
 import {
+  AccessDelegate,
+  AccessDelegateFailure,
+  AccessDelegateSuccess,
   type Service as AccessService,
   type AgentDataExport,
 } from '@web3-storage/access/types'
@@ -11,6 +14,7 @@ import type {
   Ability,
   Resource,
   Unit,
+  ServiceMethod,
 } from '@ucanto/interface'
 import { type Client } from './client.js'
 import { StorefrontService } from '@web3-storage/filecoin-client/storefront'
@@ -36,6 +40,15 @@ export interface ServiceConf {
   filecoin: ConnectionView<StorefrontService>
 }
 
+export interface ContentServeService {
+  access: {
+    delegate: ServiceMethod<
+      AccessDelegate,
+      AccessDelegateSuccess,
+      AccessDelegateFailure
+    >
+  }
+}
 export interface ClientFactoryOptions {
   /**
    * A storage driver that persists exported agent data.

--- a/packages/w3up-client/test/account.test.js
+++ b/packages/w3up-client/test/account.test.js
@@ -112,7 +112,7 @@ export const testAccount = Test.withContext({
     { client, mail, grantAccess }
   ) => {
     const space = await client.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const mnemonic = space.toMnemonic()
     const { signer } = await Space.fromMnemonic(mnemonic, { name: 'import' })
@@ -150,7 +150,7 @@ export const testAccount = Test.withContext({
   'multi device workflow': async (asserts, { connect, mail, grantAccess }) => {
     const laptop = await connect()
     const space = await laptop.createSpace('main', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
 
     // want to provision space ?
@@ -188,7 +188,7 @@ export const testAccount = Test.withContext({
   },
   'setup recovery': async (assert, { client, mail, grantAccess }) => {
     const space = await client.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
 
     const email = 'alice@web.mail'
@@ -287,7 +287,7 @@ export const testAccount = Test.withContext({
     { client, mail, grantAccess }
   ) => {
     const space = await client.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
 
     const email = 'alice@web.mail'
@@ -309,7 +309,7 @@ export const testAccount = Test.withContext({
 
   'space.save': async (assert, { client }) => {
     const space = await client.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     assert.deepEqual(client.spaces(), [])
 

--- a/packages/w3up-client/test/account.test.js
+++ b/packages/w3up-client/test/account.test.js
@@ -111,7 +111,9 @@ export const testAccount = Test.withContext({
     assert,
     { client, mail, grantAccess }
   ) => {
-    const space = await client.createSpace('test')
+    const space = await client.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const mnemonic = space.toMnemonic()
     const { signer } = await Space.fromMnemonic(mnemonic, { name: 'import' })
     assert.deepEqual(
@@ -147,7 +149,9 @@ export const testAccount = Test.withContext({
 
   'multi device workflow': async (asserts, { connect, mail, grantAccess }) => {
     const laptop = await connect()
-    const space = await laptop.createSpace('main')
+    const space = await laptop.createSpace('main', {
+      skipContentServeAuthorization: true,
+    })
 
     // want to provision space ?
     const email = 'alice@web.mail'
@@ -183,7 +187,9 @@ export const testAccount = Test.withContext({
     asserts.deepEqual(result.did, space.did())
   },
   'setup recovery': async (assert, { client, mail, grantAccess }) => {
-    const space = await client.createSpace('test')
+    const space = await client.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
 
     const email = 'alice@web.mail'
     const login = Account.login(client, email)
@@ -280,7 +286,9 @@ export const testAccount = Test.withContext({
     assert,
     { client, mail, grantAccess }
   ) => {
-    const space = await client.createSpace('test')
+    const space = await client.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
 
     const email = 'alice@web.mail'
     const login = Account.login(client, email)
@@ -299,8 +307,10 @@ export const testAccount = Test.withContext({
     assert.equal(typeof subs.results[0].subscription, 'string')
   },
 
-  'space.save': async (assert, { client, mail, grantAccess }) => {
-    const space = await client.createSpace('test')
+  'space.save': async (assert, { client }) => {
+    const space = await client.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     assert.deepEqual(client.spaces(), [])
 
     const result = await space.save()

--- a/packages/w3up-client/test/capability/access.test.js
+++ b/packages/w3up-client/test/capability/access.test.js
@@ -20,7 +20,7 @@ export const AccessClient = Test.withContext({
     },
     'should delegate and then claim': async (
       assert,
-      { connection, provisionsStorage }
+      { id: w3, connection, provisionsStorage }
     ) => {
       const alice = new Client(await AgentData.create(), {
         // @ts-ignore
@@ -29,7 +29,10 @@ export const AccessClient = Test.withContext({
           upload: connection,
         },
       })
-      const space = await alice.createSpace('upload-test')
+
+      const space = await alice.createSpace('upload-test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/capability/access.test.js
+++ b/packages/w3up-client/test/capability/access.test.js
@@ -31,7 +31,7 @@ export const AccessClient = Test.withContext({
       })
 
       const space = await alice.createSpace('upload-test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)

--- a/packages/w3up-client/test/capability/blob.test.js
+++ b/packages/w3up-client/test/capability/blob.test.js
@@ -20,7 +20,7 @@ export const BlobClient = Test.withContext({
     })
 
     const space = await alice.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
@@ -59,7 +59,7 @@ export const BlobClient = Test.withContext({
     })
 
     const space = await alice.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
@@ -99,7 +99,7 @@ export const BlobClient = Test.withContext({
     })
 
     const space = await alice.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
@@ -133,7 +133,7 @@ export const BlobClient = Test.withContext({
     })
 
     const space = await alice.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)

--- a/packages/w3up-client/test/capability/blob.test.js
+++ b/packages/w3up-client/test/capability/blob.test.js
@@ -19,7 +19,9 @@ export const BlobClient = Test.withContext({
       receiptsEndpoint: new URL(receiptsEndpoint),
     })
 
-    const space = await alice.createSpace('test')
+    const space = await alice.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
     await alice.setCurrentSpace(space.did())
@@ -56,7 +58,9 @@ export const BlobClient = Test.withContext({
       receiptsEndpoint: new URL(receiptsEndpoint),
     })
 
-    const space = await alice.createSpace('test')
+    const space = await alice.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
     await alice.setCurrentSpace(space.did())
@@ -94,7 +98,9 @@ export const BlobClient = Test.withContext({
       receiptsEndpoint: new URL(receiptsEndpoint),
     })
 
-    const space = await alice.createSpace('test')
+    const space = await alice.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
     await alice.setCurrentSpace(space.did())
@@ -126,7 +132,9 @@ export const BlobClient = Test.withContext({
       receiptsEndpoint: new URL(receiptsEndpoint),
     })
 
-    const space = await alice.createSpace('test')
+    const space = await alice.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
     await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/capability/filecoin.test.js
+++ b/packages/w3up-client/test/capability/filecoin.test.js
@@ -6,7 +6,7 @@ export const FilecoinClient = Test.withContext({
   offer: {
     'should send an offer': async (assert, { client: alice }) => {
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
@@ -39,7 +39,7 @@ export const FilecoinClient = Test.withContext({
       }
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)

--- a/packages/w3up-client/test/capability/filecoin.test.js
+++ b/packages/w3up-client/test/capability/filecoin.test.js
@@ -5,7 +5,9 @@ import * as Test from '../test.js'
 export const FilecoinClient = Test.withContext({
   offer: {
     'should send an offer': async (assert, { client: alice }) => {
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
@@ -36,7 +38,9 @@ export const FilecoinClient = Test.withContext({
         throw new Error('could not compute proof')
       }
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/capability/index.test.js
+++ b/packages/w3up-client/test/capability/index.test.js
@@ -15,7 +15,7 @@ export const IndexClient = Test.withContext({
       const car = await randomCAR(128)
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)

--- a/packages/w3up-client/test/capability/index.test.js
+++ b/packages/w3up-client/test/capability/index.test.js
@@ -14,7 +14,9 @@ export const IndexClient = Test.withContext({
     ) => {
       const car = await randomCAR(128)
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/capability/space.test.js
+++ b/packages/w3up-client/test/capability/space.test.js
@@ -19,7 +19,9 @@ export const SpaceClient = Test.withContext({
         },
       })
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice, {
         access: { 'space/info': {} },
         expiration: Infinity,
@@ -55,7 +57,9 @@ export const SpaceClient = Test.withContext({
           upload: connection,
         },
       })
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await alice.addSpace(await space.createAuthorization(alice))
       assert.ok(auth)
 
@@ -165,7 +169,9 @@ export const SpaceClient = Test.withContext({
           upload: connection,
         },
       })
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await alice.addSpace(await space.createAuthorization(alice))
       assert.ok(auth)
 
@@ -273,7 +279,9 @@ export const SpaceClient = Test.withContext({
             upload: connection,
           },
         })
-        const space = await alice.createSpace('test')
+        const space = await alice.createSpace('test', {
+          skipContentServeAuthorization: true,
+        })
         const auth = await alice.addSpace(
           await space.createAuthorization(alice)
         )
@@ -385,7 +393,9 @@ export const SpaceClient = Test.withContext({
             upload: connection,
           },
         })
-        const space = await alice.createSpace('test')
+        const space = await alice.createSpace('test', {
+          skipContentServeAuthorization: true,
+        })
         const auth = await alice.addSpace(
           await space.createAuthorization(alice)
         )
@@ -499,7 +509,9 @@ export const SpaceClient = Test.withContext({
           upload: connection,
         },
       })
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await alice.addSpace(await space.createAuthorization(alice))
       assert.ok(auth)
 

--- a/packages/w3up-client/test/capability/space.test.js
+++ b/packages/w3up-client/test/capability/space.test.js
@@ -20,7 +20,7 @@ export const SpaceClient = Test.withContext({
       })
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice, {
         access: { 'space/info': {} },
@@ -58,7 +58,7 @@ export const SpaceClient = Test.withContext({
         },
       })
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await alice.addSpace(await space.createAuthorization(alice))
       assert.ok(auth)
@@ -170,7 +170,7 @@ export const SpaceClient = Test.withContext({
         },
       })
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await alice.addSpace(await space.createAuthorization(alice))
       assert.ok(auth)
@@ -280,7 +280,7 @@ export const SpaceClient = Test.withContext({
           },
         })
         const space = await alice.createSpace('test', {
-          skipContentServeAuthorization: true,
+          skipGatewayAuthorization: true,
         })
         const auth = await alice.addSpace(
           await space.createAuthorization(alice)
@@ -394,7 +394,7 @@ export const SpaceClient = Test.withContext({
           },
         })
         const space = await alice.createSpace('test', {
-          skipContentServeAuthorization: true,
+          skipGatewayAuthorization: true,
         })
         const auth = await alice.addSpace(
           await space.createAuthorization(alice)
@@ -510,7 +510,7 @@ export const SpaceClient = Test.withContext({
         },
       })
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await alice.addSpace(await space.createAuthorization(alice))
       assert.ok(auth)

--- a/packages/w3up-client/test/capability/store.test.js
+++ b/packages/w3up-client/test/capability/store.test.js
@@ -17,7 +17,7 @@ export const StoreClient = Test.withContext({
     })
 
     const space = await alice.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
@@ -54,7 +54,7 @@ export const StoreClient = Test.withContext({
     })
 
     const space = await alice.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
@@ -92,7 +92,7 @@ export const StoreClient = Test.withContext({
     })
 
     const space = await alice.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
@@ -128,7 +128,7 @@ export const StoreClient = Test.withContext({
     })
 
     const space = await alice.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)

--- a/packages/w3up-client/test/capability/store.test.js
+++ b/packages/w3up-client/test/capability/store.test.js
@@ -16,7 +16,9 @@ export const StoreClient = Test.withContext({
       },
     })
 
-    const space = await alice.createSpace('test')
+    const space = await alice.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
     await alice.setCurrentSpace(space.did())
@@ -51,7 +53,9 @@ export const StoreClient = Test.withContext({
       },
     })
 
-    const space = await alice.createSpace('test')
+    const space = await alice.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
     await alice.setCurrentSpace(space.did())
@@ -87,7 +91,9 @@ export const StoreClient = Test.withContext({
       },
     })
 
-    const space = await alice.createSpace('test')
+    const space = await alice.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
     await alice.setCurrentSpace(space.did())
@@ -121,7 +127,9 @@ export const StoreClient = Test.withContext({
       },
     })
 
-    const space = await alice.createSpace('test')
+    const space = await alice.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
     const auth = await space.createAuthorization(alice)
     await alice.addSpace(auth)
     await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/capability/subscription.test.js
+++ b/packages/w3up-client/test/capability/subscription.test.js
@@ -8,7 +8,9 @@ export const SubscriptionClient = Test.withContext({
       assert,
       { client, connection, service, plansStorage, grantAccess, mail }
     ) => {
-      const space = await client.createSpace('test')
+      const space = await client.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const email = 'alice@web.mail'
       const login = Account.login(client, email)
       const message = await mail.take()

--- a/packages/w3up-client/test/capability/subscription.test.js
+++ b/packages/w3up-client/test/capability/subscription.test.js
@@ -9,7 +9,7 @@ export const SubscriptionClient = Test.withContext({
       { client, connection, service, plansStorage, grantAccess, mail }
     ) => {
       const space = await client.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const email = 'alice@web.mail'
       const login = Account.login(client, email)

--- a/packages/w3up-client/test/capability/upload.test.js
+++ b/packages/w3up-client/test/capability/upload.test.js
@@ -9,7 +9,9 @@ export const UploadClient = Test.withContext({
     ) => {
       const car = await randomCAR(128)
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
@@ -38,7 +40,9 @@ export const UploadClient = Test.withContext({
     ) => {
       const car = await randomCAR(128)
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
@@ -77,7 +81,9 @@ export const UploadClient = Test.withContext({
     ) => {
       const car = await randomCAR(128)
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
@@ -109,7 +115,9 @@ export const UploadClient = Test.withContext({
     ) => {
       const car = await randomCAR(128)
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/capability/upload.test.js
+++ b/packages/w3up-client/test/capability/upload.test.js
@@ -10,7 +10,7 @@ export const UploadClient = Test.withContext({
       const car = await randomCAR(128)
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
@@ -41,7 +41,7 @@ export const UploadClient = Test.withContext({
       const car = await randomCAR(128)
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
@@ -82,7 +82,7 @@ export const UploadClient = Test.withContext({
       const car = await randomCAR(128)
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
@@ -116,7 +116,7 @@ export const UploadClient = Test.withContext({
       const car = await randomCAR(128)
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)

--- a/packages/w3up-client/test/capability/usage.test.js
+++ b/packages/w3up-client/test/capability/usage.test.js
@@ -19,7 +19,7 @@ export const UsageClient = Test.withContext({
       })
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
@@ -63,7 +63,7 @@ export const UsageClient = Test.withContext({
       })
 
       const space = await alice.createSpace('test', {
-        skipContentServeAuthorization: true,
+        skipGatewayAuthorization: true,
       })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)

--- a/packages/w3up-client/test/capability/usage.test.js
+++ b/packages/w3up-client/test/capability/usage.test.js
@@ -18,7 +18,9 @@ export const UsageClient = Test.withContext({
         },
       })
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
 
@@ -60,7 +62,9 @@ export const UsageClient = Test.withContext({
         },
       })
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
 

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -17,7 +17,6 @@ import { DIDMailto } from '../src/capability/access.js'
 import {
   confirmConfirmationUrl,
   w3,
-  w3Signer,
 } from '../../upload-api/test/helpers/utils.js'
 import * as SpaceCapability from '@web3-storage/capabilities/space'
 
@@ -43,7 +42,9 @@ export const testClient = {
         receiptsEndpoint: new URL(receiptsEndpoint),
       })
 
-      const space = await alice.createSpace('upload-test')
+      const space = await alice.createSpace('upload-test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
@@ -120,7 +121,9 @@ export const testClient = {
         receiptsEndpoint: new URL(receiptsEndpoint),
       })
 
-      const space = await alice.createSpace('upload-dir-test')
+      const space = await alice.createSpace('upload-dir-test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
 
@@ -165,7 +168,9 @@ export const testClient = {
         receiptsEndpoint: new URL(receiptsEndpoint),
       })
 
-      const space = await alice.createSpace('car-space')
+      const space = await alice.createSpace('car-space', {
+        skipContentServeAuthorization: true,
+      })
       await alice.addSpace(await space.createAuthorization(alice))
       await alice.setCurrentSpace(space.did())
 
@@ -226,7 +231,9 @@ export const testClient = {
       const current0 = alice.currentSpace()
       assert.equal(current0, undefined)
 
-      const space = await alice.createSpace('new-space')
+      const space = await alice.createSpace('new-space', {
+        skipContentServeAuthorization: true,
+      })
       await alice.addSpace(await space.createAuthorization(alice))
       await alice.setCurrentSpace(space.did())
 
@@ -240,7 +247,9 @@ export const testClient = {
       const alice = new Client(await AgentData.create())
 
       const name = `space-${Date.now()}`
-      const space = await alice.createSpace(name)
+      const space = await alice.createSpace(name, {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
 
@@ -254,7 +263,9 @@ export const testClient = {
       const alice = new Client(await AgentData.create())
       const bob = new Client(await AgentData.create())
 
-      const space = await alice.createSpace('new-space')
+      const space = await alice.createSpace('new-space', {
+        skipContentServeAuthorization: true,
+      })
       await alice.addSpace(
         await space.createAuthorization(alice, {
           access: { '*': {} },
@@ -577,7 +588,9 @@ export const testClient = {
       const alice = new Client(await AgentData.create())
       const bob = new Client(await AgentData.create())
 
-      const space = await alice.createSpace('proof-space')
+      const space = await alice.createSpace('proof-space', {
+        skipContentServeAuthorization: true,
+      })
       await alice.addSpace(await space.createAuthorization(alice))
       await alice.setCurrentSpace(space.did())
 
@@ -595,7 +608,9 @@ export const testClient = {
       const alice = new Client(await AgentData.create())
       const bob = new Client(await AgentData.create())
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       await alice.addSpace(await space.createAuthorization(alice))
       await alice.setCurrentSpace(space.did())
       const name = `delegation-${Date.now()}`
@@ -631,7 +646,9 @@ export const testClient = {
         },
       })
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       await alice.addSpace(
         await space.createAuthorization(alice, {
           access: { '*': {} },
@@ -653,7 +670,9 @@ export const testClient = {
       const alice = new Client(await AgentData.create())
       const bob = new Client(await AgentData.create())
 
-      const space = await alice.createSpace('test')
+      const space = await alice.createSpace('test', {
+        skipContentServeAuthorization: true,
+      })
       await alice.addSpace(await space.createAuthorization(alice))
       await alice.setCurrentSpace(space.did())
       const name = `delegation-${Date.now()}`
@@ -704,7 +723,9 @@ export const testClient = {
       })
 
       // setup space
-      const space = await alice.createSpace('upload-test')
+      const space = await alice.createSpace('upload-test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
@@ -753,7 +774,9 @@ export const testClient = {
         })
 
         // setup space
-        const space = await alice.createSpace('upload-test')
+        const space = await alice.createSpace('upload-test', {
+          skipContentServeAuthorization: true,
+        })
         const auth = await space.createAuthorization(alice)
         await alice.addSpace(auth)
         await alice.setCurrentSpace(space.did())
@@ -805,7 +828,9 @@ export const testClient = {
       })
 
       // setup space
-      const space = await alice.createSpace('upload-test')
+      const space = await alice.createSpace('upload-test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
@@ -829,7 +854,9 @@ export const testClient = {
       })
 
       // setup space
-      const space = await alice.createSpace('upload-test')
+      const space = await alice.createSpace('upload-test', {
+        skipContentServeAuthorization: true,
+      })
       const auth = await space.createAuthorization(alice)
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -554,11 +554,12 @@ export const testClient = {
       await client.setCurrentSpace(spaceA.did())
 
       // Step 3: Authorize the gateway to serve content from the space
-      const delegation = await client.authorizeContentServe(spaceA, {
+      const delegationResult = await client.authorizeContentServe(spaceA, {
         audience: w3.did(),
         connection: connection,
       })
-      assert.ok(delegation)
+      assert.ok(delegationResult.ok)
+      const { delegation } = delegationResult.ok
 
       // Step 4: Find the delegation for the default gateway
       assert.equal(delegation.audience.did(), 'did:web:staging.w3s.link')

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -10,7 +10,7 @@ import {
 import { randomBytes, randomCAR } from './helpers/random.js'
 import { toCAR } from './helpers/car.js'
 import { File } from './helpers/shims.js'
-import { Client } from '../src/client.js'
+import { authorizeContentServe, Client } from '../src/client.js'
 import * as Test from './test.js'
 import { receiptsEndpoint } from './helpers/utils.js'
 import { Absentee } from '@ucanto/principal'
@@ -595,7 +595,8 @@ export const testClient = {
         ).connection
 
         // Step 3: Alice authorizes the gateway to serve content from the space
-        const delegationResult = await aliceClient.authorizeContentServe(
+        const delegationResult = await authorizeContentServe(
+          aliceClient,
           spaceA,
           gatewayConnection
         )

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -14,7 +14,11 @@ import * as Test from './test.js'
 import { receiptsEndpoint } from './helpers/utils.js'
 import { Absentee } from '@ucanto/principal'
 import { DIDMailto } from '../src/capability/access.js'
-import { confirmConfirmationUrl } from '../../upload-api/test/helpers/utils.js'
+import {
+  confirmConfirmationUrl,
+  w3,
+  w3Signer,
+} from '../../upload-api/test/helpers/utils.js'
 import * as SpaceCapability from '@web3-storage/capabilities/space'
 
 /** @type {Test.Suite} */
@@ -532,7 +536,7 @@ export const testClient = {
   authorizeGateway: Test.withContext({
     'should authorize a gateway to serve content from a space': async (
       assert,
-      { client, mail, grantAccess }
+      { client, mail, grantAccess, connection }
     ) => {
       // Step 1: Create a client for Alice and login
       const aliceEmail = 'alice@web.mail'
@@ -550,9 +554,9 @@ export const testClient = {
       await client.setCurrentSpace(spaceA.did())
 
       // Step 3: Authorize the gateway to serve content from the space
-      const delegation = await client.authorizeGateway(spaceA, {
-        gateway: 'did:web:staging.w3s.link',
-        expiration: Infinity,
+      const delegation = await client.authorizeContentServe(spaceA, {
+        audience: w3.did(),
+        connection: connection,
       })
       assert.ok(delegation)
 
@@ -560,7 +564,6 @@ export const testClient = {
       assert.equal(delegation.audience.did(), 'did:web:staging.w3s.link')
       assert.ok(
         delegation.capabilities.some(
-          // @ts-expect-error
           (c) =>
             c.can === SpaceCapability.contentServe.can &&
             c.with === spaceA.did()

--- a/packages/w3up-client/test/coupon.test.js
+++ b/packages/w3up-client/test/coupon.test.js
@@ -37,7 +37,9 @@ export const testCoupon = Test.withContext({
     const access = await alice.coupon.redeem(archive)
 
     // creates a space and provision it with redeemed coupon
-    const space = await alice.createSpace('home')
+    const space = await alice.createSpace('home', {
+      skipContentServeAuthorization: true,
+    })
     const result = await space.provision(access)
     await space.save()
 

--- a/packages/w3up-client/test/coupon.test.js
+++ b/packages/w3up-client/test/coupon.test.js
@@ -38,7 +38,7 @@ export const testCoupon = Test.withContext({
 
     // creates a space and provision it with redeemed coupon
     const space = await alice.createSpace('home', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
     const result = await space.provision(access)
     await space.save()

--- a/packages/w3up-client/test/mocks/service.js
+++ b/packages/w3up-client/test/mocks/service.js
@@ -5,6 +5,7 @@ import * as AccessCaps from '@web3-storage/capabilities'
 
 /**
  * Mocked Gateway/Content Serve service
+ *
  * @param {{ ok: any } | { error: Server.API.Failure }} result
  */
 export function getContentServeMockService(result = { ok: {} }) {
@@ -20,8 +21,8 @@ export function getContentServeMockService(result = { ok: {} }) {
 /**
  * Generic function to create connection to any type of mock service with any type of signer id.
  *
- * @param {any} service
  * @param {any} id
+ * @param {any} service
  */
 export function getConnection(id, service) {
   const server = Server.create({

--- a/packages/w3up-client/test/mocks/service.js
+++ b/packages/w3up-client/test/mocks/service.js
@@ -1,0 +1,43 @@
+import * as Client from '@ucanto/client'
+import * as Server from '@ucanto/server'
+import * as CAR from '@ucanto/transport/car'
+
+import * as AccessCaps from '@web3-storage/capabilities'
+
+/**
+ * Mocked Gateway/Content Serve service
+ */
+export function getMockService() {
+  return {
+    access: {
+      delegate: Server.provide(
+        AccessCaps.Access.delegate,
+        async ({ capability, invocation }) => {
+          return {
+            ok: {},
+          }
+        }
+      ),
+    },
+  }
+}
+
+/**
+ * @param {any} service
+ * @param {any} id
+ */
+export function getConnection(id, service) {
+  const server = Server.create({
+    id: id,
+    service,
+    codec: CAR.inbound,
+    validateAuthorization: () => ({ ok: {} }),
+  })
+  const connection = Client.connect({
+    id: id,
+    codec: CAR.outbound,
+    channel: server,
+  })
+
+  return { connection }
+}

--- a/packages/w3up-client/test/mocks/service.js
+++ b/packages/w3up-client/test/mocks/service.js
@@ -1,5 +1,6 @@
 import * as Client from '@ucanto/client'
 import * as Server from '@ucanto/server'
+import { HTTP } from '@ucanto/transport'
 import * as CAR from '@ucanto/transport/car'
 import * as AccessCaps from '@web3-storage/capabilities'
 
@@ -23,8 +24,9 @@ export function getContentServeMockService(result = { ok: {} }) {
  *
  * @param {any} id
  * @param {any} service
+ * @param {string | undefined} [url]
  */
-export function getConnection(id, service) {
+export function getConnection(id, service, url = undefined) {
   const server = Server.create({
     id: id,
     service,
@@ -34,7 +36,7 @@ export function getConnection(id, service) {
   const connection = Client.connect({
     id: id,
     codec: CAR.outbound,
-    channel: server,
+    channel: url ? HTTP.open({ url: new URL(url) }) : server,
   })
 
   return { connection }

--- a/packages/w3up-client/test/mocks/service.js
+++ b/packages/w3up-client/test/mocks/service.js
@@ -1,28 +1,25 @@
 import * as Client from '@ucanto/client'
 import * as Server from '@ucanto/server'
 import * as CAR from '@ucanto/transport/car'
-
 import * as AccessCaps from '@web3-storage/capabilities'
 
 /**
  * Mocked Gateway/Content Serve service
+ * @param {{ ok: any } | { error: Server.API.Failure }} result
  */
-export function getMockService() {
+export function getContentServeMockService(result = { ok: {} }) {
   return {
     access: {
-      delegate: Server.provide(
-        AccessCaps.Access.delegate,
-        async ({ capability, invocation }) => {
-          return {
-            ok: {},
-          }
-        }
-      ),
+      delegate: Server.provide(AccessCaps.Access.delegate, async () => {
+        return result
+      }),
     },
   }
 }
 
 /**
+ * Generic function to create connection to any type of mock service with any type of signer id.
+ *
  * @param {any} service
  * @param {any} id
  */

--- a/packages/w3up-client/test/space.test.js
+++ b/packages/w3up-client/test/space.test.js
@@ -24,7 +24,9 @@ export const testSpace = Test.withContext({
   },
 
   'should get usage': async (assert, { client, grantAccess, mail }) => {
-    const space = await client.createSpace('test')
+    const space = await client.createSpace('test', {
+      skipContentServeAuthorization: true,
+    })
 
     const email = 'alice@web.mail'
     const login = Account.login(client, email)

--- a/packages/w3up-client/test/space.test.js
+++ b/packages/w3up-client/test/space.test.js
@@ -25,7 +25,7 @@ export const testSpace = Test.withContext({
 
   'should get usage': async (assert, { client, grantAccess, mail }) => {
     const space = await client.createSpace('test', {
-      skipContentServeAuthorization: true,
+      skipGatewayAuthorization: true,
     })
 
     const email = 'alice@web.mail'


### PR DESCRIPTION
### Context
To enable a gateway to serve content from a specific space, we must ensure that the space owner delegates the `space/content/serve/*` capability to the Gateway. This delegation allows the Gateway to serve content and log egress events appropriately.

I created a new function `authorizeContentServe` for this implementation and included it in the `createSpace` flow. This is a breaking change because now the user is forced to provide the DIDs of the Content Serve services, and the connection, or skip the authorization flow.

Additionally, with the `authorizeContentServe` function, we can implement a feature in the Console App that enables users to explicitly authorize the Freeway Gateway to serve content from existing/legacy spaces.

### Main Changes
- **New Functionality:** Added a new function, `authorizeContentServe`, in the `w3up-client` module to facilitate the delegation process. Integrated it with the `createdSpace` flow.
- **Testing:** Introduced test cases to verify the authorization of specified gateways.
- **Fixes:** Resolved issues with previously broken test cases (Egress Record).

### Related Issues
- https://github.com/storacha/project-tracking/issues/158
- https://github.com/storacha/project-tracking/issues/160