### PR TITLE
fix: retry when PUT request fails

### DIFF
--- a/packages/upload-client/test/blob.test.js
+++ b/packages/upload-client/test/blob.test.js
@@ -499,7 +499,7 @@ describe('Blob.add', () => {
     )
   })
 
-  it('throws for bucket URL server error 5xx', async function() {
+  it('throws for bucket URL server error 5xx', async function () {
     // allow time for retries
     this.timeout(10_000)
 

--- a/packages/upload-client/test/blob.test.js
+++ b/packages/upload-client/test/blob.test.js
@@ -499,7 +499,10 @@ describe('Blob.add', () => {
     )
   })
 
-  it('throws for bucket URL server error 5xx', async () => {
+  it('throws for bucket URL server error 5xx', async function() {
+    // allow time for retries
+    this.timeout(10_000)
+
     const space = await Signer.generate()
     const agent = await Signer.generate()
     const bytes = await randomBytes(128)


### PR DESCRIPTION
FML, we have a useless retry function that does not retry the PUT request when fetch response is non-200.

Not any more.