### PR TITLE
chore(capabilities): top level filecoin cap

### DIFF
--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "attw": "attw --pack .",
     "lint": "tsc && eslint '**/*.{js,ts}' && prettier --check '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",
+    "lint:fix": "tsc && eslint '**/*.{js,ts}' --fix && prettier --write '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "check": "tsc --build",

--- a/packages/capabilities/src/filecoin/index.js
+++ b/packages/capabilities/src/filecoin/index.js
@@ -17,4 +17,5 @@ export {
   filecoinSubmit as submit,
   filecoinAccept as accept,
   filecoinInfo as info,
+  filecoin as filecoin,
 } from './storefront.js'

--- a/packages/capabilities/src/filecoin/storefront.js
+++ b/packages/capabilities/src/filecoin/storefront.js
@@ -14,6 +14,18 @@ import { PieceLink } from './lib.js'
 import { equalWith, checkLink, and } from '../utils.js'
 
 /**
+ * Top-level capability for Filecoin operations.
+ */
+export const filecoin = capability({
+  can: 'filecoin/*',
+  /**
+   * DID of the space the content is stored in.
+   */
+  with: Schema.did(),
+  derives: equalWith,
+})
+
+/**
  * Capability allowing an agent to _request_ storing a content piece in
  * Filecoin.
  */

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -808,9 +808,7 @@ export interface AdminStoreInspectSuccess {
 }
 export type AdminStoreInspectFailure = Ucanto.Failure
 // Filecoin
-export type Filecoin = InferInvokedCapability<
-  typeof StorefrontCaps.filecoin
->
+export type Filecoin = InferInvokedCapability<typeof StorefrontCaps.filecoin>
 export type FilecoinOffer = InferInvokedCapability<
   typeof StorefrontCaps.filecoinOffer
 >

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -808,6 +808,9 @@ export interface AdminStoreInspectSuccess {
 }
 export type AdminStoreInspectFailure = Ucanto.Failure
 // Filecoin
+export type Filecoin = InferInvokedCapability<
+  typeof StorefrontCaps.filecoin
+>
 export type FilecoinOffer = InferInvokedCapability<
   typeof StorefrontCaps.filecoinOffer
 >
@@ -921,6 +924,7 @@ export type ServiceAbilityArray = [
   RateLimitAdd['can'],
   RateLimitRemove['can'],
   RateLimitList['can'],
+  Filecoin['can'],
   FilecoinOffer['can'],
   FilecoinSubmit['can'],
   FilecoinAccept['can'],

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -354,10 +354,7 @@ export class Client extends Base {
         'upload/*',
         'access/*',
         'usage/*',
-        'filecoin/offer',
-        'filecoin/info',
-        'filecoin/accept',
-        'filecoin/submit',
+        'filecoin/*',
       ],
       expiration: Infinity,
     }


### PR DESCRIPTION
### Changes
- Added the Filecoin top-level capability.
- Updated w3up-client to use it instead of defining all of the filecoin capabilities.

### Related Issues
Resolves: https://github.com/storacha/w3up/issues/1554