### PR TITLE
fix: export web3.storage service factory

### DIFF
--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -54,6 +54,9 @@
       "rate-limit": [
         "dist/src/rate-limit.d.ts"
       ],
+      "service": [
+        "dist/src/service.d.ts"
+      ],
       "space": [
         "dist/src/space.d.ts"
       ],
@@ -141,6 +144,10 @@
     "./rate-limit": {
       "types": "./dist/src/rate-limit.d.ts",
       "import": "./src/rate-limit.js"
+    },
+    "./service": {
+      "types": "./dist/src/service.d.ts",
+      "import": "./src/service.js"
     },
     "./space": {
       "types": "./dist/src/space.d.ts",


### PR DESCRIPTION
 Export the factory for creating legacy `web3.storage/blob/allocate` and `web3.storage/blob/accept` handlers.

Required for https://github.com/storacha/RFC/pull/38