### PR TITLE
feat: external login

### DIFF
--- a/packages/access-client/src/access.js
+++ b/packages/access-client/src/access.js
@@ -127,6 +127,28 @@ export const claim = async (
 }
 
 /**
+ * Creates a new `PendingAccessRequest` object that can be used to poll for the
+ * requested delegation through `access/claim` capability.
+ *
+ * @param {API.Agent} agent
+ * @param {object} input
+ * @param {API.Link} input.request - Link to the `access/authorize` invocation.
+ * @param {API.UTCUnixTimestamp} input.expiration - Seconds in UTC.
+ * @param {API.DID} [input.audience] - Principal requesting an access.
+ * @param {API.ProviderDID} [input.provider] - Provider handling request.
+ */
+export const createPendingAccessRequest = (
+  agent,
+  {
+    request,
+    expiration,
+    provider = /** @type {API.ProviderDID} */ (agent.connection.id.did()),
+    audience: audience = agent.did(),
+  }
+) =>
+  new PendingAccessRequest({ agent, request, expiration, provider, audience })
+
+/**
  * Represents a pending access request. It can be used to poll for the requested
  * delegation.
  */

--- a/packages/capabilities/src/access.js
+++ b/packages/capabilities/src/access.js
@@ -41,7 +41,7 @@ export const AuthorizationRequest = Schema.struct({
   /**
    * DID of the Account authorization is requested from.
    */
-  iss: Account,
+  iss: Account.optional(),
   /**
    * Capabilities agent wishes to be granted.
    */

--- a/packages/filecoin-api/src/aggregator/buffer-reducing.js
+++ b/packages/filecoin-api/src/aggregator/buffer-reducing.js
@@ -208,13 +208,17 @@ export function aggregatePieces(bufferedPieces, config) {
     builder.offset * BigInt(NODE_SIZE) +
     BigInt(builder.limit) * BigInt(Index.EntrySize)
 
-  console.log(`Used ${totalUsedSpace} bytes in ${addedBufferedPieces.length} pieces (min ${config.minAggregateSize} bytes)`)
+  console.log(
+    `Used ${totalUsedSpace} bytes in ${addedBufferedPieces.length} pieces (min ${config.minAggregateSize} bytes)`
+  )
 
   // If not enough space return undefined
   if (totalUsedSpace < BigInt(config.minAggregateSize)) {
     // ...but only if not exceeded max aggregate pieces
     if (addedBufferedPieces.length === config.maxAggregatePieces) {
-      console.warn(`Building aggregate: max allowed pieces reached (${config.maxAggregatePieces})`)
+      console.warn(
+        `Building aggregate: max allowed pieces reached (${config.maxAggregatePieces})`
+      )
     } else {
       return console.log('Not enough data for aggregate.')
     }

--- a/packages/filecoin-api/src/aggregator/events.js
+++ b/packages/filecoin-api/src/aggregator/events.js
@@ -233,7 +233,7 @@ export const handleAggregateInsertToPieceAcceptQueue = async (
      * @param piece
      * @returns {Promise<import('@ucanto/interface').Result<import('@ucanto/interface').Unit, RangeError|import('../types.js').QueueAddError>>}
      */
-    async piece => {
+    async (piece) => {
       const inclusionProof = aggregateBuilder.resolveProof(piece.link)
       if (inclusionProof.error) return inclusionProof
 

--- a/packages/filecoin-api/test/context/store-implementations.js
+++ b/packages/filecoin-api/test/context/store-implementations.js
@@ -17,7 +17,9 @@ export const getStoreImplementations = () => ({
           queryFn: (items, search, options) => {
             const results = Array.from(items)
               .filter((i) => i.insertedAt > (options?.cursor ?? ''))
-              .filter((i) => search.status ? i.status === search.status : true)
+              .filter((i) =>
+                search.status ? i.status === search.status : true
+              )
               .sort((a, b) => (a.insertedAt > b.insertedAt ? 1 : -1))
               .slice(0, options?.size ?? items.size)
             return { results, cursor: results.at(-1)?.insertedAt }
@@ -208,7 +210,7 @@ export const getStoreImplementations = () => ({
             return nItem
           },
         })
-      ),
+      )
     ),
   },
   dealTracker: {

--- a/packages/filecoin-api/test/events/aggregator.js
+++ b/packages/filecoin-api/test/events/aggregator.js
@@ -586,7 +586,10 @@ export const test = {
         }))
       )
       assert.ok(handledMessageRes.ok)
-      assert.equal(handledMessageRes.ok?.aggregatedPieces, config.maxAggregatePieces)
+      assert.equal(
+        handledMessageRes.ok?.aggregatedPieces,
+        config.maxAggregatePieces
+      )
 
       await pWaitFor(
         () =>

--- a/packages/upload-api/src/access/authorize.js
+++ b/packages/upload-api/src/access/authorize.js
@@ -22,7 +22,9 @@ export const provide = (ctx) =>
  */
 export const authorize = async ({ capability, invocation }, ctx) => {
   if (!capability.nb.iss) {
-    return Server.error(new Error('Issuer is required in invoked authorization request.'))
+    return Server.error(
+      new Error('Issuer is required in invoked authorization request.')
+    )
   }
 
   const accountMailtoDID =

--- a/packages/upload-api/src/access/authorize.js
+++ b/packages/upload-api/src/access/authorize.js
@@ -21,6 +21,10 @@ export const provide = (ctx) =>
  * @returns {Promise<API.Transaction<API.AccessAuthorizeSuccess, API.AccessAuthorizeFailure>>}
  */
 export const authorize = async ({ capability, invocation }, ctx) => {
+  if (!capability.nb.iss) {
+    return Server.error(new Error('Issuer is required in invoked authorization request.'))
+  }
+
   const accountMailtoDID =
     /** @type {import('@web3-storage/did-mailto/types').DidMailto} */ (
       capability.nb.iss

--- a/packages/upload-api/src/access/authorize.js
+++ b/packages/upload-api/src/access/authorize.js
@@ -74,7 +74,8 @@ export const authorize = async ({ capability, invocation }, ctx) => {
       nb: {
         // we copy request details and set the `aud` field to the agent DID
         // that requested the authorization.
-        ...capability.nb,
+        iss: accountMailtoDID,
+        att: capability.nb.att,
         aud: capability.with,
         // Link to the invocation that requested the authorization.
         cause: invocation.cid,

--- a/packages/upload-api/src/blob/accept.js
+++ b/packages/upload-api/src/blob/accept.js
@@ -55,7 +55,12 @@ export function blobAcceptProvider(context) {
       })
 
       // Publish this claim to the content claims service
-      const pubClaim = await publishLocationClaim(context, { space, digest, size: blob.size, location: createUrl.ok })
+      const pubClaim = await publishLocationClaim(context, {
+        space,
+        digest,
+        size: blob.size,
+        location: createUrl.ok,
+      })
       if (pubClaim.error) {
         return pubClaim
       }
@@ -159,7 +164,7 @@ const publishLocationClaim = async (ctx, { digest, size, location }) => {
       nb: {
         content: { digest: digest.bytes },
         location: [location],
-        range: { offset: 0, length: size }
+        range: { offset: 0, length: size },
       },
       expiration: Infinity,
       proofs,

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -203,7 +203,10 @@ import { StorageGetError } from './types/storage.js'
 import { AllocationsStorage, BlobsStorage, BlobAddInput } from './types/blob.js'
 export type { AllocationsStorage, BlobsStorage, BlobAddInput }
 import { IPNIService, IndexServiceContext } from './types/index.js'
-import { ClaimsClientConfig, ClaimsClientContext } from './types/content-claims.js'
+import {
+  ClaimsClientConfig,
+  ClaimsClientContext,
+} from './types/content-claims.js'
 import { Claim } from '@web3-storage/content-claims/client/api'
 export type {
   IndexServiceContext,
@@ -366,26 +369,28 @@ export interface W3sService {
   }
 }
 
-export type BlobServiceContext = SpaceServiceContext & ClaimsClientContext & {
-  /**
-   * Service signer
-   */
-  id: Signer
-  maxUploadSize: number
-  allocationsStorage: AllocationsStorage
-  blobsStorage: BlobsStorage
-  agentStore: AgentStore
-  getServiceConnection: () => ConnectionView<Service>
-}
+export type BlobServiceContext = SpaceServiceContext &
+  ClaimsClientContext & {
+    /**
+     * Service signer
+     */
+    id: Signer
+    maxUploadSize: number
+    allocationsStorage: AllocationsStorage
+    blobsStorage: BlobsStorage
+    agentStore: AgentStore
+    getServiceConnection: () => ConnectionView<Service>
+  }
 
-export type W3ServiceContext = SpaceServiceContext & ClaimsClientContext & {
-  /**
-   * Service signer
-   */
-  id: Signer
-  allocationsStorage: AllocationsStorage
-  blobsStorage: BlobsStorage
-}
+export type W3ServiceContext = SpaceServiceContext &
+  ClaimsClientContext & {
+    /**
+     * Service signer
+     */
+    id: Signer
+    allocationsStorage: AllocationsStorage
+    blobsStorage: BlobsStorage
+  }
 
 export type StoreServiceContext = SpaceServiceContext & {
   maxUploadSize: number

--- a/packages/upload-api/src/types/usage.ts
+++ b/packages/upload-api/src/types/usage.ts
@@ -27,6 +27,6 @@ export interface UsageStorage {
     /** The date and time when the resource was served. */
     servedAt: Date,
     /** Identifier of the invocation that caused the egress traffic. */
-    cause: UnknownLink,
+    cause: UnknownLink
   ) => Promise<Result<EgressData, Failure>>
 }

--- a/packages/upload-api/test/handlers/blob.js
+++ b/packages/upload-api/test/handlers/blob.js
@@ -117,7 +117,7 @@ export const test = {
       proofs: [proof],
       // Note: we have to set an expiration, or the default expiration value
       // will be set when the invocation is executed and the UCAN issued.
-      expiration: (Math.floor(Date.now() / 1000)) + 10
+      expiration: Math.floor(Date.now() / 1000) + 10,
     })
     // Invoke `blob/add` for the first time
     const firstBlobAdd = await invocation.execute(connection)
@@ -152,7 +152,9 @@ export const test = {
     const firstAllocateTaskLink = firstNext.allocate.task.link()
     const secondAllocateTaskLink = secondNext.allocate.task.link()
 
-    if (firstAllocateTaskLink.toString() !== secondAllocateTaskLink.toString()) {
+    if (
+      firstAllocateTaskLink.toString() !== secondAllocateTaskLink.toString()
+    ) {
       console.error('allocate receipts not equal:')
       console.error(firstNext.allocate.receipt)
       console.error(secondNext.allocate.receipt)
@@ -464,7 +466,11 @@ export const test = {
         body: data,
         headers: address.headers,
       })
-      assert.equal(httpPut.status, 200, `PUT ${address.url} failed (${httpPut.status}): ${await httpPut.text()}`)
+      assert.equal(
+        httpPut.status,
+        200,
+        `PUT ${address.url} failed (${httpPut.status}): ${await httpPut.text()}`
+      )
     }
 
     const keys =
@@ -487,7 +493,7 @@ export const test = {
     // ensure a location claim exists for the content root
     const claims = Result.unwrap(await context.claimsService.read(digest))
     assert.ok(
-      claims.some(c => c.type === 'assert/location'),
+      claims.some((c) => c.type === 'assert/location'),
       'did not find location claim'
     )
   },

--- a/packages/w3up-client/src/account.js
+++ b/packages/w3up-client/src/account.js
@@ -123,6 +123,7 @@ export const login = async ({ agent }, email, options = {}) => {
   }
 }
 
+/* c8 ignore start */
 /**
  * Attempts to obtain account access for an out of band authentication process.
  * e.g. OAuth.
@@ -186,6 +187,7 @@ export const externalLogin = async (
 
   return { ok: new Account({ id: account, proofs: ok.proofs, agent }) }
 }
+/* c8 ignore end */
 
 /**
  * @param {API.Delegation} d

--- a/packages/w3up-client/src/account.js
+++ b/packages/w3up-client/src/account.js
@@ -126,7 +126,7 @@ export const login = async ({ agent }, email, options = {}) => {
 /**
  * Attempts to obtain account access for an out of band authentication process.
  * e.g. OAuth.
- * 
+ *
  * Authentication is typically performed out of band by an OAuth provider. In
  * the OAuth callback, a delegation for the requested capabilities is issued
  * _from_ the email reported by the OAuth provider _to_ the agent. The service
@@ -143,8 +143,14 @@ export const login = async ({ agent }, email, options = {}) => {
  * @param {string} [input.receiptsEndpoint]
  * @returns {Promise<API.Result<Account, Error>>}
  */
-export const externalLogin = async ({ agent }, { request, expiration, ...options }) => {
-  const access = Access.createPendingAccessRequest({ agent }, { request, expiration })
+export const externalLogin = async (
+  { agent },
+  { request, expiration, ...options }
+) => {
+  const access = Access.createPendingAccessRequest(
+    { agent },
+    { request, expiration }
+  )
 
   const { ok, error } = await access.claim({ signal: options.signal })
   /* c8 ignore next 2 - don't know how to test this */
@@ -185,7 +191,7 @@ export const externalLogin = async ({ agent }, { request, expiration, ...options
  * @param {API.Delegation} d
  * @returns {d is API.Delegation<[API.UCANAttest]>}
  */
-const isUCANAttest = d => d.capabilities[0].can === UCAN.attest.can
+const isUCANAttest = (d) => d.capabilities[0].can === UCAN.attest.can
 
 /**
  * @typedef {object} Model

--- a/packages/w3up-client/src/capability/access.js
+++ b/packages/w3up-client/src/capability/access.js
@@ -93,6 +93,20 @@ export const request = async ({ agent }, input) =>
   Agent.Access.request(agent, input)
 
 /**
+ * Creates a new `PendingAccessRequest` object that can be used to poll for the
+ * requested delegation through `access/claim` capability.
+ *
+ * @param {{agent: API.Agent}} agent
+ * @param {object} input
+ * @param {API.Link} input.request - Link to the `access/authorize` invocation.
+ * @param {API.UTCUnixTimestamp} input.expiration - Seconds in UTC.
+ * @param {API.DID} [input.audience] - Principal requesting an access.
+ * @param {API.ProviderDID} [input.provider] - Provider handling request.
+ */
+export const createPendingAccessRequest = ({ agent }, input) =>
+  Agent.Access.createPendingAccessRequest(agent, input)
+
+/**
  *
  * @param {{agent: API.Agent}} agent
  * @param {object} input

--- a/packages/w3up-client/src/capability/access.js
+++ b/packages/w3up-client/src/capability/access.js
@@ -103,6 +103,7 @@ export const request = async ({ agent }, input) =>
  * @param {API.DID} [input.audience] - Principal requesting an access.
  * @param {API.ProviderDID} [input.provider] - Provider handling request.
  */
+/* c8 ignore next 2 */
 export const createPendingAccessRequest = ({ agent }, input) =>
   Agent.Access.createPendingAccessRequest(agent, input)
 

--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -122,6 +122,7 @@ export type {
   FilecoinInfo,
   FilecoinInfoSuccess,
   FilecoinInfoFailure,
+  UCANAttest,
 } from '@web3-storage/capabilities/types'
 
 export type {
@@ -178,3 +179,5 @@ export type {
   BlobLike,
   ProgressStatus,
 } from '@web3-storage/upload-client/types'
+
+export type { UTCUnixTimestamp } from '@ipld/dag-ucan'


### PR DESCRIPTION
refs https://github.com/storacha/RFC/pull/43

This PR adds a new method `externalLogin()` that allow login to the system via an external method (e.g. OAuth). It essentially bypasses email confirmation, assuming this is done out of band. We re-join the regular auth flow at the point when we claim the delegation (and attestation) from an email to the agent.

