### PR TITLE
feat: port of https://github.com/storacha/upload-service/commit/2c12c23d13d14e9f1b79c34b8169f20975d431f7

### DIFF
--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -343,3 +343,7 @@ export type EncodedDelegation<C extends Capabilities = Capabilities> = string &
 
 export type BytesDelegation<C extends Capabilities = Capabilities> =
   Uint8Array & Phantom<Delegation<C>>
+
+export enum AppName {
+  BskyBackups = 'bsky-backups',
+}

--- a/packages/upload-api/src/access/authorize.js
+++ b/packages/upload-api/src/access/authorize.js
@@ -82,6 +82,12 @@ export const authorize = async ({ capability, invocation }, ctx) => {
         // Link to the invocation that requested the authorization.
         cause: invocation.cid,
       },
+      // we copy the facts in so that information can be passed
+      // from the invoker of this capability to the invoker of the confirm
+      // capability - we use this, for example, to let bsky.storage users
+      // specify that they should be redirected back to bsky.storage after
+      // completing the Stripe plan selection flow
+      facts: invocation.facts,
     })
     .delegate()
 

--- a/packages/upload-api/src/validate.js
+++ b/packages/upload-api/src/validate.js
@@ -59,6 +59,7 @@ export async function authorize(encodedUcan, env) {
         email: DidMailto.toEmail(DidMailto.fromString(account.did())),
         audience: agent.did(),
         ucan: delegationsToString(confirmDelegations),
+        facts: request.facts,
       },
     }
   } catch (error) {

--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -20,6 +20,7 @@ import { type Client } from './client.js'
 import { StorefrontService } from '@web3-storage/filecoin-client/storefront'
 export * from '@ucanto/interface'
 export * from '@web3-storage/did-mailto'
+export { AppName } from '@web3-storage/access/types'
 export type { Agent, CapabilityQuery } from '@web3-storage/access/agent'
 export type {
   Access,


### PR DESCRIPTION
Ports over the upload api changes in the above commit to upload service

-- original commit message
feat: add `app` to `access/authorize` and `access/confirm` (#264) (

We need a way to ensure users are redirected back to `https://bsky.storage` after completing the Stripe checkout process.

To facilitate this, pass facts from `access/authorize` to`access/confirm` - users can now add a fact like `{app: 'bsky-backups'}` to `access/authorize`, which will tell the `access/confirm` handling code in `w3infra` to render the same pricing table we use on https://bsky.storage which sends the user back to that app after picking a plan via the email flow.

Add support for this to the client code via a new `appName` option in the account creation functions that gets converted to a fact at the lowest level.

There are a bunch of ways we could do this, but in the interest of shipping ASAP I think this is a reasonable and fast way to go.

See https://github.com/storacha/w3infra/pull/472 for the other part of this.